### PR TITLE
flexible json filenames

### DIFF
--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -1,15 +1,17 @@
+import json, argparse, math, numpy as np, matplotlib.pyplot as plt
 from collections import Counter
-import json
-import argparse
 from ast import literal_eval
-import matplotlib.pyplot as plt
-import numpy as np
 from scipy.interpolate import griddata
 from scipy.optimize import curve_fit
-import math
 
 parser = argparse.ArgumentParser()
 
+parser.add_argument(
+    "filename",
+    nargs="?",
+    help="json file with WDL statistics",
+    default="scoreWDLstat.json",
+)
 parser.add_argument(
     "--NormalizeToPawnValue",
     type=int,
@@ -42,8 +44,8 @@ fig.suptitle("Summary of win-draw-loss model analysis", fontsize="x-large")
 #
 # read score stats as obtained from fishtest games
 #
-print("reading data")
-with open("scoreWDLstat.json", "r") as infile:
+print(f"Reading data from {args.filename}.")
+with open(args.filename) as infile:
     inputdata = json.load(infile)
 print("Done.")
 

--- a/scoreWDLana_material.py
+++ b/scoreWDLana_material.py
@@ -1,15 +1,22 @@
+import json, argparse, numpy as np, matplotlib.pyplot as plt
 from collections import Counter
-import json
 from ast import literal_eval
-import matplotlib.pyplot as plt
-import numpy as np
 from scipy.interpolate import griddata
 
+parser = argparse.ArgumentParser()
 
-with open("scoreWDLstat.json", "r") as infile:
+parser.add_argument(
+    "filename",
+    nargs="?",
+    help="json file with WDL statistics",
+    default="scoreWDLstat.json",
+)
+args = parser.parse_args()
+
+print(f"Reading data from {args.filename}.")
+with open(args.filename) as infile:
     inputdata = json.load(infile)
-
-print("read data")
+print("Done.")
 
 inpdict = {literal_eval(k): v for k, v in inputdata.items()}
 

--- a/scoreWDLana_moves.py
+++ b/scoreWDLana_moves.py
@@ -1,15 +1,22 @@
+import json, argparse, numpy as np, matplotlib.pyplot as plt
 from collections import Counter
-import json
 from ast import literal_eval
-import matplotlib.pyplot as plt
-import numpy as np
 from scipy.interpolate import griddata
 
+parser = argparse.ArgumentParser()
 
-with open("scoreWDLstat.json", "r") as infile:
+parser.add_argument(
+    "filename",
+    nargs="?",
+    help="json file with WDL statistics",
+    default="scoreWDLstat.json",
+)
+args = parser.parse_args()
+
+print(f"Reading data from {args.filename}.")
+with open(args.filename) as infile:
     inputdata = json.load(infile)
-
-print("read data")
+print("Done.")
 
 inpdict = {literal_eval(k): v for k, v in inputdata.items()}
 

--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -254,21 +254,27 @@ void ana_files(map_t &map, const std::vector<std::string> &files) {
 
 /// @brief
 /// @param argc
-/// @param argv Possible ones are --dir and --file
+/// @param argv Possible ones are --dir, --file and -o
 /// @return
 int main(int argc, char const *argv[]) {
     const std::vector<std::string> args(argv + 1, argv + argc);
 
     std::vector<std::string> files_pgn;
 
-    if (std::find(args.begin(), args.end(), "--dir") != args.end()) {
-        const auto path = std::find(args.begin(), args.end(), "--dir") + 1;
-        files_pgn       = get_files(*path);
-    } else if (std::find(args.begin(), args.end(), "--file") != args.end()) {
-        const auto path = std::find(args.begin(), args.end(), "--file") + 1;
-        files_pgn       = {*path};
+    auto pos = std::find(args.begin(), args.end(), "--dir");
+    if (pos != args.end() && std::next(pos) != args.end()) {
+        files_pgn = get_files(*std::next(pos));
+    } else if ((pos = std::find(args.begin(), args.end(), "--file")) != args.end() &&
+               std::next(pos) != args.end()) {
+        files_pgn = {*std::next(pos)};
     } else {
         files_pgn = get_files();
+    }
+
+    std::string jsonFile = "scoreWDLstat.json";
+    if ((pos = std::find(args.begin(), args.end(), "-o")) != args.end() &&
+        std::next(pos) != args.end()) {
+        jsonFile = *std::next(pos);
     }
 
     // Create more chunks than threads to prevent threads from idling.
@@ -335,11 +341,12 @@ int main(int argc, char const *argv[]) {
     }
 
     // save json to file
-    std::ofstream outFile("scoreWDLstat.json");
+    std::ofstream outFile(jsonFile);
     outFile << j.dump(2);
     outFile.close();
 
-    std::cout << "Retained " << total << " scored positions for analysis." << std::endl;
+    std::cout << "Wrote " << total << " scored positions to " << jsonFile << " for analysis."
+              << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
This PR adds the option `-o` to `scoreWDLstat` to allow different names for the json file. While at it, ensure that cli options have a parameter.

Also update the python scripts accordingly.