### PR TITLE
provide script to merge JSON files

### DIFF
--- a/jsonmerge.py
+++ b/jsonmerge.py
@@ -1,0 +1,30 @@
+import argparse, json
+
+
+def merge_file(filename, merged_data):
+    with open(filename) as file:
+        data = json.load(file)
+        for key, value in data.items():
+            merged_data[key] = merged_data.get(key, 0) + value
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Merge several JSON files.")
+    parser.add_argument("input", nargs="+", help="JSON files to merge")
+    parser.add_argument(
+        "-o", "--output", default="merged_data.json", help="merged JSON file"
+    )
+    args = parser.parse_args()
+
+    merged_data = {}
+    for filename in args.input:
+        merge_file(filename, merged_data)
+
+    with open(args.output, "w") as output_file:
+        json.dump(merged_data, output_file, indent=4)
+
+    print(f"Merging JSON file saved to {args.output}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The json files use far less space than the full pgn collections, and grow only little in size once a sufficient number of games have been analyzed.

So the idea is to allow users (and scripts) to periodically scrape pgn's from fishtest, without having to keep the pgn's until the final conversion to json.

For final automation would need some tweaks to the download script, as this currently relies on downloaded pgn file names to avoid duplicates. Not sure if the script can be tweaked to only download all test that completed on the previous day, for example.