### PR TITLE
revert total_chunks counter initialization change

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -54,7 +54,7 @@ struct std::hash<Key> {
 // unordered map to count (outcome, move, material, score) tuples in pgns
 using map_t = std::unordered_map<Key, int>;
 
-std::atomic<std::size_t> total_chunks = 1;
+std::atomic<std::size_t> total_chunks = 0;
 
 namespace analysis {
 


### PR DESCRIPTION
This reverts one change from https://github.com/official-stockfish/WDL_model/pull/26. The original code by @Disservin is correct, I was misled by local results, which at the time always ended one short of `files_chunked.size()`. Sorry.