### PR TITLE
assign full move number to move, rather than number of moves out of book

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -161,10 +161,8 @@ void ana_game(map_t &pos_map, const std::optional<Game> &game, const std::string
         board.set960(true);
     }
 
-    int ply = 0;
-
     for (const auto &move : game.value().moves()) {
-        if (++ply > 400) {
+        if (board.fullMoveNumber() > 200) {
             break;
         }
 
@@ -200,7 +198,7 @@ void ana_game(map_t &pos_map, const std::optional<Game> &game, const std::string
 
         if (key.score != 1002) {  // a score was found
             key.outcome = board.sideToMove() == Color::WHITE ? resultkey.white : resultkey.black;
-            key.move    = (ply + 1) / 2;  // move number
+            key.move    = board.fullMoveNumber();
             const auto knights = builtin::popcount(board.pieces(PieceType::KNIGHT));
             const auto bishops = builtin::popcount(board.pieces(PieceType::BISHOP));
             const auto rooks   = builtin::popcount(board.pieces(PieceType::ROOK));


### PR DESCRIPTION
For the current fishtest pgn data, this PR is nonfunctional.

However, going forward, and e.g. applying the counter fix from https://github.com/official-stockfish/WDL_model/issues/34#issuecomment-1707824528, the model can now be based on the true full move number.

PS: Once we fit do such corrected pgn data, we need to decide whether to shift the anchor from 32 to 40.