### PR TITLE
add chess variant to subdir structure

### DIFF
--- a/download_fishtest_pgns.py
+++ b/download_fishtest_pgns.py
@@ -14,7 +14,7 @@ parser.add_argument(
 parser.add_argument(
     "--subdirs",
     action="store_true",
-    help="use PATH/date/test-id/ (sub)directory structure",
+    help="use PATH/variant/date/test-id/ (sub)directory structure",
 )
 parser.add_argument(
     "--page",


### PR DESCRIPTION
Not sure if this is the right way to go, hence draft for now.

This PR would allow to separate the pgn data based on chess variant played, without any additional changes to the other scripts in this repo.

Initially I thought FRC and DFRC do not use depth 8 books, and so this would have been necessary to get the move count information right. Having checked that also FRC and DFRC seem to use 8-move books, this PR is less urgent from that point of view.

The script has not been tested with actual FRC or DFRC LTC tests, as I could not easily find a page of the form https://tests.stockfishchess.org/tests/finished?ltc_only=1&page=1 that contains such tests.