### PR TITLE
use API for metadata

### DIFF
--- a/download_fishtest_pgns.py
+++ b/download_fishtest_pgns.py
@@ -1,4 +1,4 @@
-import argparse, json, os, re, requests, tarfile, time, urllib.request
+import argparse, json, os, re, requests, tarfile, urllib.request
 
 parser = argparse.ArgumentParser(
     description="Bulk-download .pgn.gz files from completed LTC tests on fishtest.",

--- a/download_fishtest_pgns.py
+++ b/download_fishtest_pgns.py
@@ -1,5 +1,4 @@
-import urllib.request, urllib.error, urllib.parse, requests, tarfile
-import argparse, time, re, os, json
+import argparse, json, os, re, requests, tarfile, time, urllib.request
 
 parser = argparse.ArgumentParser(
     description="Bulk-download .pgn.gz files from completed LTC tests on fishtest.",
@@ -76,8 +75,7 @@ for test, dateStr in ids:
         print(f"Collecting meta data for test {test} ...")
     url = "https://tests.stockfishchess.org/api/get_run/" + test
     try:
-        response = requests.get(url)
-        meta = response.json()
+        meta = requests.get(url).json()
         if "spsa" in meta.get("args", {}):
             if args.verbose >= 1:
                 print(f"Skipping SPSA test {test} ...")

--- a/download_fishtest_pgns.py
+++ b/download_fishtest_pgns.py
@@ -1,4 +1,4 @@
-import urllib.request, urllib.error, urllib.parse, tarfile
+import urllib.request, urllib.error, urllib.parse, requests, tarfile
 import argparse, time, re, os, json
 
 parser = argparse.ArgumentParser(
@@ -64,56 +64,29 @@ for line in webContent:
             dateStr = line.strip()
         nextlineDate = line.endswith('"run-date">')
 
-# download all pgns, together with some of the tests' meta data...
+# download metadata and .pgn.tar ball for each test
 for test, dateStr in ids:
-    url = "https://tests.stockfishchess.org/tests/view/" + test
-    response = urllib.request.urlopen(url)
-    webContent = response.read().decode("utf-8").splitlines()
-    if "<td>spsa</td>" in "".join(webContent):
-        if args.verbose >= 1:
-            print(f"Skipping SPSA test {test} ...")
-        continue
     path = args.path + dateStr + "/" + test + "/"
     if not os.path.exists(args.path + dateStr):
         os.makedirs(args.path + dateStr)
     if not os.path.exists(path):
         os.makedirs(path)
+
     if args.verbose >= 1:
         print(f"Collecting meta data for test {test} ...")
-    meta = {}
-    keyStrs = [
-        "adjudication",  # first the keywords that have the value on next but one line
-        "base_net",
-        "base_options",
-        "base_tag",
-        "book",
-        "book_depth",
-        "new_net",
-        "new_options",
-        "new_tag",
-        "new_tc",
-        "sprt",
-        "tc",
-        "threads",
-        "start time",  # then the keywords that appear on the same line as the value
-        "last updated",
-    ]
-    p = re.compile("<td>([0-9 :\-]*)</td>")
-    for i, line in enumerate(webContent):
-        if i < 2:
+    url = "https://tests.stockfishchess.org/api/get_run/" + test
+    try:
+        response = requests.get(url)
+        meta = response.json()
+        with open(path + test + ".json", "w") as jsonFile:
+            json.dump(meta, jsonFile, indent=4, sort_keys=True)
+        if "spsa" in meta:
+            if args.verbose >= 1:
+                print(f"Skipping SPSA test {test} ...")
             continue
-        for keyStr in keyStrs[:-2]:
-            if webContent[i - 2].endswith(f"<td>{keyStr}</td>"):
-                meta[keyStr] = line.strip()
-        for keyStr in keyStrs[-2:]:
-            if keyStr in line:
-                meta[keyStr] = p.search(line).group(1)
-    for keyStr in keyStrs:
-        if keyStr not in meta:
-            if args.verbose >= 2:
-                print(f"Could not find {keyStr} information at {url}.")
-    with open(path + test + ".json", "w") as jsonFile:
-        json.dump(meta, jsonFile, indent=4, sort_keys=True)
+    except Exception as ex:
+        if args.verbose >= 2:
+            print(f'  error: caught exception "{ex}"')
 
     print(f"Downloading {test}.pgns.tar to {path} ...")
     url = "https://tests.stockfishchess.org/api/run_pgns/" + test + ".pgns.tar"

--- a/download_fishtest_pgns.py
+++ b/download_fishtest_pgns.py
@@ -80,7 +80,7 @@ for test, dateStr in ids:
         meta = response.json()
         with open(path + test + ".json", "w") as jsonFile:
             json.dump(meta, jsonFile, indent=4, sort_keys=True)
-        if "spsa" in meta:
+        if "spsa" in meta.get("args", {}):
             if args.verbose >= 1:
                 print(f"Skipping SPSA test {test} ...")
             continue

--- a/download_fishtest_pgns.py
+++ b/download_fishtest_pgns.py
@@ -78,12 +78,12 @@ for test, dateStr in ids:
     try:
         response = requests.get(url)
         meta = response.json()
-        with open(path + test + ".json", "w") as jsonFile:
-            json.dump(meta, jsonFile, indent=4, sort_keys=True)
         if "spsa" in meta.get("args", {}):
             if args.verbose >= 1:
                 print(f"Skipping SPSA test {test} ...")
             continue
+        with open(path + test + ".json", "w") as jsonFile:
+            json.dump(meta, jsonFile, indent=4, sort_keys=True)
     except Exception as ex:
         if args.verbose >= 2:
             print(f'  error: caught exception "{ex}"')

--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -303,7 +303,7 @@ void filter_files_sprt(std::vector<std::string> &file_list, const map_meta &meta
 
         // check if metadata and "sprt" entry exist
         if (meta_map.find(test_filename) != meta_map.end() &&
-            meta_map.at(test_filename).sprt.has_value()) {
+            meta_map.at(test_filename).sprt.value()) {
             return false;
         }
 

--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -303,6 +303,7 @@ void filter_files_sprt(std::vector<std::string> &file_list, const map_meta &meta
 
         // check if metadata and "sprt" entry exist
         if (meta_map.find(test_filename) != meta_map.end() &&
+            meta_map.at(test_filename).sprt.has_value() &&
             meta_map.at(test_filename).sprt.value()) {
             return false;
         }

--- a/scoreWDLstat.hpp
+++ b/scoreWDLstat.hpp
@@ -42,22 +42,9 @@ struct std::hash<Key> {
 };
 
 struct TestMetaData {
-    std::optional<std::string> base_net;
-    std::optional<std::string> base_options;
-    std::optional<std::string> base_tag;
     std::optional<std::string> book;
-    std::optional<std::string> last_updated;
-    std::optional<std::string> new_net;
-    std::optional<std::string> new_options;
-    std::optional<std::string> new_tag;
-    std::optional<std::string> new_tc;
     std::optional<std::string> sprt;
-    std::optional<std::string> start_time;
-    std::optional<std::string> tc;
-
-    std::optional<int> threads;
     std::optional<int> book_depth;
-    std::optional<bool> adjudication;
 };
 
 template <typename T = std::string>
@@ -71,51 +58,14 @@ std::optional<T> get_optional(const nlohmann::json &j, const char *name) {
 }
 
 void from_json(const nlohmann::json &nlohmann_json_j, TestMetaData &nlohmann_json_t) {
-    auto j = nlohmann_json_j;
+    auto &j = nlohmann_json_j["args"];
 
-    // Check if args key is present, if so we are using metadata from the fishtest api
-    if (j.find("args") != j.end()) {
-        nlohmann_json_t.start_time   = get_optional(nlohmann_json_j, "start_time");
-        nlohmann_json_t.last_updated = get_optional(nlohmann_json_j, "last_updated");
+    nlohmann_json_t.book_depth =
+        get_optional(j, "book_depth").has_value()
+            ? std::optional<int>(std::stoi(get_optional(j, "book_depth").value()))
+            : std::nullopt;
 
-        j = j["args"];
-
-        nlohmann_json_t.adjudication = get_optional<bool>(j, "adjudication");
-
-        nlohmann_json_t.threads = get_optional<int>(j, "threads");
-
-        nlohmann_json_t.book_depth =
-            get_optional(j, "book_depth").has_value()
-                ? std::optional<int>(std::stoi(get_optional(j, "book_depth").value()))
-                : std::nullopt;
-
-    } else {
-        nlohmann_json_t.start_time = get_optional(nlohmann_json_j, "start time");
-
-        nlohmann_json_t.last_updated = get_optional(nlohmann_json_j, "last updated");
-
-        nlohmann_json_t.adjudication = get_optional(j, "adjudication").value_or("False") == "True";
-
-        nlohmann_json_t.book_depth =
-            get_optional(j, "book_depth").has_value()
-                ? std::optional<int>(std::stoi(get_optional(j, "book_depth").value()))
-                : std::nullopt;
-
-        nlohmann_json_t.threads =
-            get_optional(j, "threads").has_value()
-                ? std::optional<int>(std::stoi(get_optional(j, "threads").value()))
-                : std::nullopt;
-    }
-
-    nlohmann_json_t.tc           = get_optional(j, "tc");
-    nlohmann_json_t.base_net     = get_optional(j, "base_net");
-    nlohmann_json_t.base_options = get_optional(j, "base_options");
-    nlohmann_json_t.base_tag     = get_optional(j, "base_tag");
-    nlohmann_json_t.book         = get_optional(j, "book");
-    nlohmann_json_t.new_net      = get_optional(j, "new_net");
-    nlohmann_json_t.new_options  = get_optional(j, "new_options");
-    nlohmann_json_t.new_tag      = get_optional(j, "new_tag");
-    nlohmann_json_t.new_tc       = get_optional(j, "new_tc");
+    nlohmann_json_t.book = get_optional(j, "book");
 }
 
 /// @brief Custom stof implementation to avoid locale issues, once clang supports std::from_chars

--- a/scoreWDLstat.hpp
+++ b/scoreWDLstat.hpp
@@ -66,6 +66,7 @@ void from_json(const nlohmann::json &nlohmann_json_j, TestMetaData &nlohmann_jso
             : std::nullopt;
 
     nlohmann_json_t.book = get_optional(j, "book");
+    nlohmann_json_t.sprt = get_optional(j, "sprt");
 }
 
 /// @brief Custom stof implementation to avoid locale issues, once clang supports std::from_chars

--- a/scoreWDLstat.hpp
+++ b/scoreWDLstat.hpp
@@ -65,7 +65,7 @@ void from_json(const nlohmann::json &nlohmann_json_j, TestMetaData &nlohmann_jso
             ? std::optional<int>(std::stoi(get_optional(j, "book_depth").value()))
             : std::nullopt;
 
-    nlohmann_json_t.sprt = get_optional(j, "sprt").has_value();
+    nlohmann_json_t.sprt = j.contains("sprt") ? std::optional<bool>(true) : std::nullopt;
 
     nlohmann_json_t.book = get_optional(j, "book");
 }

--- a/scoreWDLstat.hpp
+++ b/scoreWDLstat.hpp
@@ -43,7 +43,7 @@ struct std::hash<Key> {
 
 struct TestMetaData {
     std::optional<std::string> book;
-    std::optional<std::string> sprt;
+    std::optional<bool> sprt;
     std::optional<int> book_depth;
 };
 
@@ -65,8 +65,9 @@ void from_json(const nlohmann::json &nlohmann_json_j, TestMetaData &nlohmann_jso
             ? std::optional<int>(std::stoi(get_optional(j, "book_depth").value()))
             : std::nullopt;
 
+    nlohmann_json_t.sprt = get_optional(j, "sprt").has_value();
+
     nlohmann_json_t.book = get_optional(j, "book");
-    nlohmann_json_t.sprt = get_optional(j, "sprt");
 }
 
 /// @brief Custom stof implementation to avoid locale issues, once clang supports std::from_chars


### PR DESCRIPTION
Draft for now, as it only gets the new metadata from the fishtest API.

~~I have not tested yet if this detect SPSA tests correctly (probably does not, will fix.)~~

But I wanted to publish this draft as it will need help from @Disservin to filter the json data within our .hpp file.
Could you check if the `"args"` key is present in the data, and then use the new format? Otherwise try the old format? Thanks a lot. You can push your changes to the .hpp file directly here.