### PR TITLE
skip tests that do not match revisions

### DIFF
--- a/scoreWDLstat.hpp
+++ b/scoreWDLstat.hpp
@@ -50,7 +50,7 @@ struct std::equal_to<Key> {
 };
 
 struct TestMetaData {
-    std::optional<std::string> book;
+    std::optional<std::string> book, resolved_base, resolved_new;
     std::optional<bool> sprt;
     std::optional<int> book_depth;
 };
@@ -75,7 +75,9 @@ void from_json(const nlohmann::json &nlohmann_json_j, TestMetaData &nlohmann_jso
 
     nlohmann_json_t.sprt = j.contains("sprt") ? std::optional<bool>(true) : std::nullopt;
 
-    nlohmann_json_t.book = get_optional(j, "book");
+    nlohmann_json_t.book          = get_optional(j, "book");
+    nlohmann_json_t.resolved_base = get_optional(j, "resolved_base");
+    nlohmann_json_t.resolved_new  = get_optional(j, "resolved_new");
 }
 
 /// @brief Custom stof implementation to avoid locale issues, once clang supports std::from_chars

--- a/updateWDL.sh
+++ b/updateWDL.sh
@@ -38,7 +38,7 @@ newepoch=$(git show --quiet --format=%ci $lastrev)
 # build a regex pattern to match all revisions
 regex_pattern=""
 for rev in $revs; do
-    regex_pattern="${regex_pattern}.*-$rev|"
+    regex_pattern="${regex_pattern}.*$rev|"
     newpawn=$(git grep 'const int NormalizeToPawnValue' $rev -- src/uci.h | grep -oP 'const int NormalizeToPawnValue = \K\d+')
     if [[ $oldpawn -ne $newpawn ]]; then
         echo "Revision $rev has wrong NormalizeToPawnValue ($newpawn != $oldpawn)"
@@ -56,7 +56,7 @@ echo "Look recursively in directory $pgnpath for games from SPRT tests using" \
     "$oldepoch) and $lastrev (from $newepoch)."
 
 # obtain the WDL data from games of SPRT tests of the SF revisions of interest
-./scoreWDLstat --dir $pgnpath -r --matchEngine $regex_pattern --matchBook "$bookname" --fixFEN --SPRTonly -o updateWDL.json >&scoreWDLstat.log
+./scoreWDLstat --dir $pgnpath -r --matchRev $regex_pattern --matchBook "$bookname" --fixFEN --SPRTonly -o updateWDL.json >&scoreWDLstat.log
 
 # fit the new WDL model, keeping anchor at move 32
 # we ignore the first 2 full moves out of book for fitting (11=8+1+2), and the first 9 for (contour) plotting (18=8+1+9)


### PR DESCRIPTION
Use the metadata to skip whole tests if they do not involve the SF revisions of interest.

`> diff master.log patch.log`:
```diff
1a2
> Found 101774 .pgn(.gz) files in total.
3c4,5
< Found 73747 .pgn(.gz) files, creating 96 chunks for processing.
---
> Filtering pgn files matching revision SHA .*38e830af4bfa6c9e9c11279a8e6a60b6ca4ec2cd|.*002636362e175134c6d0d53b332b527ec4a12db0|.*7a4de96159f76f2465d474d76e08a1c8ca3383b8|.*f7fbc6880efae2ec9d97d6f1d65e2ad00547e32c|.*25d444ed60e3873c02a70525776b145f03833103|.*008d59512ac38e1e4a2f7880fe4e07b902845bb0|.*c17a657b045d4dc720c8c36558fe649a1c3f4a05|.*040dfedb3457ca6971d98c754362cde4dc767aff|.*f1ce1cd4751a098b7ee09e304fa6397d08fe8d7f|.*8a912951de6d4bff78d3ff5258213a0c7e6f494e|.*afe7f4d9b0c5e1a1aa224484d2cd9e04c7f099b9|.*660da1ca7b4c2c03dce03d14ef3496d9fb4aead2|.*4f0fecad8a0f5258114f63f0ac0c905a54d65219|.*31d0b7fe932458d6661f4d4c2ce88502086616c5|.*243f7b264a81c2981cec2818b47d609d9d3ca119|.*9739ed7a97c153c3223b608b24717edbf2dfd7bc|.*ce99b4b2ef74d09499f35f09bc33102d203791cd|.*22cdb6c1ea1f5ca429333bcbe26706c8b4dd38d7|.*70ba9de85cddc5460b1ec53e0a99bee271e26ece
> Found 48737 .pgn(.gz) files, creating 96 chunks for processing.
5c7
< Time taken: 117.269s
---
> Time taken: 79.278s
```

A pitfall for future users may be that they devise a regex for the commit SHA, which then does not work for the engine name in the pgn files. I put extra info in help output, but still something to be aware of. I  do not think there is an elegant and easy solution to resolve this. At the end of the day, users will be best advised to use separate regexes for revisions and engine names.