### PR TITLE
introduce --fixFENsource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@
 *.pgn
 *.gz
 *.log
+*.exe
+
+scoreWDLstat
 
 pgns*
-scoreWDLstat
-*.exe
 Stockfish
+books

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.png
 *.json
 *.pgn
-*.pgn.gz
+*.gz
 *.log
 
 pgns*

--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -35,12 +35,12 @@ map_t pos_map = {};
 // map to collect metadata for tests
 using map_meta = std::unordered_map<std::string, TestMetaData>;
 
-// class (and map) to hold data that cutechess-cli lost from original FENs
+// class (and map) to hold data that cutechess-cli changed from original FENs
 class FixFenData {
    public:
-    std::string ep;
-    int halfmove;
-    int fullmove;
+    std::string ep;  // possibly changed to '-' by cutechess-cli
+    int halfmove;    // for .epd books changed to 0 by cutechess-cli
+    int fullmove;    // for .epd books changed to 1 by cutechess-cli
 
     FixFenData() {}
     FixFenData(const std::string &ep, int halfmove, int fullmove)

--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -95,11 +95,11 @@ class Analyze : public pgn::Visitor {
 
     void header(std::string_view key, std::string_view value) override {
         if (key == "FEN") {
-            std::regex p("^(.+) - 0 1$");
+            std::regex p("^(.+) .+ 0 1$");
             std::smatch match;
             std::string value_str(value);
 
-            // revert change by cutechess-cli of move counters in .epd books to "0 1"
+            // revert changes by cutechess-cli to ep square and move counters
             if (!fixfen_map.empty() && std::regex_search(value_str, match, p) && match.size() > 1) {
                 std::string fen = match[1];
                 auto it         = fixfen_map.find(fen);

--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -95,12 +95,12 @@ class Analyze : public pgn::Visitor {
 
     void header(std::string_view key, std::string_view value) override {
         if (key == "FEN") {
-            std::regex p("^(.+) .+ 0 1$");
+            std::regex p("^(.+) (.+) 0 1$");
             std::smatch match;
             std::string value_str(value);
 
-            // revert changes by cutechess-cli to ep square and move counters
-            if (!fixfen_map.empty() && std::regex_search(value_str, match, p) && match.size() > 1) {
+            // revert changes by cutechess-cli to move counters, but trust it on ep square
+            if (!fixfen_map.empty() && std::regex_search(value_str, match, p) && match.size() > 2) {
                 std::string fen = match[1];
                 auto it         = fixfen_map.find(fen);
                 if (it == fixfen_map.end()) {
@@ -108,7 +108,8 @@ class Analyze : public pgn::Visitor {
                     std::exit(1);
                 }
                 const auto &fix         = it->second;
-                std::string fixed_value = fen + " " + fix.ep + " " + std::to_string(fix.halfmove) +
+                std::string ep          = match[2];  // trust cutechess-cli on this one
+                std::string fixed_value = fen + " " + ep + " " + std::to_string(fix.halfmove) +
                                           " " + std::to_string(fix.fullmove);
                 board.setFen(fixed_value);
             } else {

--- a/updateWDL.sh
+++ b/updateWDL.sh
@@ -66,7 +66,7 @@ echo "Look recursively in directory $pgnpath for games from SPRT tests using" \
     "$oldepoch) and $lastrev (from $newepoch)."
 
 # obtain the WDL data from games of SPRT tests of the SF revisions of interest
-./scoreWDLstat --dir $pgnpath -r --matchRev $regex_pattern --matchBook "$bookname" --fixFEN --SPRTonly -o updateWDL.json >&scoreWDLstat.log
+./scoreWDLstat --dir $pgnpath -r --matchRev $regex_pattern --matchBook "$bookname" --fixFENsource "$bookname.gz" --SPRTonly -o updateWDL.json >&scoreWDLstat.log
 
 # fit the new WDL model, keeping anchor at move 32
 # we ignore the first 2 full moves out of book for fitting (11=8+1+2), and the first 9 for (contour) plotting (18=8+1+9)

--- a/updateWDL.sh
+++ b/updateWDL.sh
@@ -9,25 +9,32 @@ echo "started at: " $(date)
 firstrev=70ba9de85cddc5460b1ec53e0a99bee271e26ece
 lastrev=HEAD
 
-# regex for book name
+# "regex" for book name, TODO: only works for single book name for now!
 bookname=UHO_4060_v3.epd
 
 # path for PGN files
 pgnpath=pgns
 
-# clone SF if needed
-if [[ ! -e Stockfish ]]; then
-    git clone https://github.com/official-stockfish/Stockfish.git >&clone.log
+# clone repos if needed, and pull latest revisions
+for repo in "Stockfish" "books"; do
+    if [[ ! -e "$repo" ]]; then
+        git clone https://github.com/official-stockfish/"$repo".git >&clone.log
+    fi
+    cd "$repo"
+    git checkout master >&checkout.log
+    git fetch origin >&fetch.log
+    git pull >&pull.log
+    cd ..
+done
+
+# get the book necessary for the move counter fixing, TODO: deal with several books
+if [[ ! -e "$bookname.gz" ]]; then
+    unzip "books/$bookname.zip"
+    gzip "$bookname"
 fi
 
-# compile scoreWDLstat if needed
-make >&make.log
-
-# update SF and get a revision list
+# get a SF revision list
 cd Stockfish
-git checkout master >&checkout.log
-git fetch origin >&fetch.log
-git pull >&pull.log
 revs=$(git rev-list $firstrev^..$lastrev)
 
 # get the currently valid value of NormalizeToPawnValue
@@ -50,6 +57,9 @@ done
 regex_pattern="${regex_pattern%|}"
 
 cd ..
+
+# compile scoreWDLstat if needed
+make >&make.log
 
 echo "Look recursively in directory $pgnpath for games from SPRT tests using" \
     "books matching \"$bookname\" for SF revisions between $firstrev (from" \


### PR DESCRIPTION
Nonfunctional change for me when running `./updateWDL.sh` .

Some comments:

- As indicated on [discord](https://discord.com/channels/435943710472011776/1032922913499783169/1166296059182579803), the book `UHO_4060_v3.epd` seems to contain impossible ep squares, which are then removed by cutechess-cli.
- Hence the `std::unordered_map<std::string, FixFenData>` uses the first _three_ FEN fields as key, not the first four.
- Storing the ep data from the book is not really necessary, and can be simplified away in future. Then `FixFenData` could just be replaced by `std::pair<int, int>`.
- Currently the update script can only deal with a single book. Some thought is needed how to allow multiple books. (download separately, create a merged `book.epd.gz`, or feed regex to the analysis script for books to read in for reference).
- But already in its current state it can be used to analyse games from only the new book.