### PR TITLE
small clean up for recent commits

### DIFF
--- a/download_fishtest_pgns.py
+++ b/download_fishtest_pgns.py
@@ -11,16 +11,16 @@ parser.add_argument(
     help="Downloaded .pgn.gz files will be stored in PATH/date/test-id/.",
 )
 parser.add_argument(
-    "--ltc_only",
-    type=bool,
-    default=True,
-    help="A flag for LTC tests only.",
-)
-parser.add_argument(
     "--time_delta",
     type=float,
     default=168.0,  # 1 week
     help="Delta of hours from now since the desired tests are last updated.",
+)
+parser.add_argument(
+    "--ltc_only",
+    type=bool,
+    default=True,
+    help="A flag for LTC tests only.",
 )
 parser.add_argument(
     "--success_only",

--- a/scoreWDLstat.hpp
+++ b/scoreWDLstat.hpp
@@ -52,7 +52,6 @@ struct std::equal_to<Key> {
 struct TestMetaData {
     std::optional<std::string> book, resolved_base, resolved_new;
     std::optional<bool> sprt;
-    std::optional<int> book_depth;
 };
 
 template <typename T = std::string>
@@ -67,11 +66,6 @@ std::optional<T> get_optional(const nlohmann::json &j, const char *name) {
 
 void from_json(const nlohmann::json &nlohmann_json_j, TestMetaData &nlohmann_json_t) {
     auto &j = nlohmann_json_j["args"];
-
-    nlohmann_json_t.book_depth =
-        get_optional(j, "book_depth").has_value()
-            ? std::optional<int>(std::stoi(get_optional(j, "book_depth").value()))
-            : std::nullopt;
 
     nlohmann_json_t.sprt = j.contains("sprt") ? std::optional<bool>(true) : std::nullopt;
 


### PR DESCRIPTION
- `ep` data read from reference book is not needed and can be removed
- `book_depth` in metadata is no longer needed and can be removed
- cosmetic change in the order of cli parameters for the download script