### PR TITLE
ignore duplicate lines and lines without full move counter

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -286,12 +286,15 @@ void ana_files(const std::vector<std::string> &files, const std::string &regex_e
             int halfmove, fullmove = 0;
 
             iss >> f1 >> f2 >> f3 >> ep >> halfmove >> fullmove;
+
+            if (!fullmove) continue;
+
             key              = f1 + ' ' + f2 + ' ' + f3;
             auto fixfen_data = std::pair<int, int>(halfmove, fullmove);
 
             if (fixfen_map.find(key) != fixfen_map.end()) {
                 // for duplicate FENs, prefer the one with lower full move counter
-                if (fullmove && fullmove < fixfen_map[key].second) {
+                if (fullmove < fixfen_map[key].second) {
                     fixfen_map[key] = fixfen_data;
                 }
             } else {

--- a/updateWDL.sh
+++ b/updateWDL.sh
@@ -10,7 +10,7 @@ firstrev=70ba9de85cddc5460b1ec53e0a99bee271e26ece
 lastrev=HEAD
 
 # regex for book name
-bookname="UHO_4060_v3.epd|UHO_Lichess_4852_v1.epd"
+bookname="UHO_4060_v..epd|UHO_Lichess_4852_v1.epd"
 
 # path for PGN files
 pgnpath=pgns
@@ -31,14 +31,16 @@ done
 bookhash=$(echo -n "$bookname" | md5sum | cut -d ' ' -f 1)
 fixfen=fixfen_"$bookhash".epd
 if [[ ! -e "$fixfen.gz" ]]; then
+    rm -f "$fixfen"
     for file in books/*.zip; do
         book=$(basename "$file" .zip)
         if [[ $book =~ $bookname ]]; then
-            unzip "$file" >&unzip.log
-            cat "$book" >>"$fixfen"
+            unzip -o "$file" >&unzip.log
+            awk 'NF >= 6' "$book" >>"$fixfen"
             rm "$book"
         fi
     done
+    sort -u "$fixfen" -o _tmp_"$fixfen" && mv _tmp_"$fixfen" "$fixfen"
     gzip "$fixfen"
 fi
 


### PR DESCRIPTION
This PR fixes a small oversight in `scoreWDLstat.cpp` that would have led to corrupt data if the reference file contained EPDs without move counters.

In addition, when creating the reference file in `updateWDL.sh`, we now immediately reject lines without move counters, and we remove any duplicate lines. This allows us to include also tests with older UHO books in the analysis. (This latter point seems to be irrelevant for my downloaded tests.)

Incidentally, I noticed that even for the _same_ book, if the lines are sorted, then the resulting `.gz` is much smaller! Something to keep in mind for future fishtest books, maybe (assuming that same holds for the `.zip` files). @vondele 

`diff master.log scoreWDLstat.log`
```diff
3c3
< Filtering pgn files matching the book name UHO_4060_v3.epd|UHO_Lichess_4852_v1.epd
---
> Filtering pgn files matching the book name UHO_4060_v..epd|UHO_Lichess_4852_v1.epd
6c6
Progress: 64/96Error when parsing: pgns/23-10-16/652d94dede6d262d08d30c99/652d94dede6d262d08d30c99-535.pgn.gz
---
Progress: 63/96Error when parsing: pgns/23-10-16/652d94dede6d262d08d30c99/652d94dede6d262d08d30c99-535.pgn.gz
8,9c8,9
Progress: 96/96
< Time taken: 838.858s
---
Progress: 96/96
> Time taken: 834.52s
```