### PR TITLE
minor cleanup and variable renaming

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -25,7 +25,7 @@ using json   = nlohmann::json;
 
 using namespace chess;
 
-// unordered map to count (outcome, move, material, score) tuples in pgns
+// unordered map to count (result, move, material, eval) tuples in pgns
 using map_t =
     phmap::parallel_flat_hash_map<Key, int, std::hash<Key>, std::equal_to<Key>,
                                   std::allocator<std::pair<const Key, int>>, 8, std::mutex>;
@@ -162,36 +162,36 @@ class Analyze : public pgn::Visitor {
         const size_t delimiter_pos = comment.find('/');
 
         Key key;
-        key.score = 1002;
+        key.eval = 1002;
 
         if (!do_filter || filter_side == board.sideToMove()) {
             if (delimiter_pos != std::string::npos && comment != "book") {
-                const auto match_score = comment.substr(0, delimiter_pos);
+                const auto match_eval = comment.substr(0, delimiter_pos);
 
-                if (match_score[1] == 'M') {
-                    if (match_score[0] == '+') {
-                        key.score = 1001;
+                if (match_eval[1] == 'M') {
+                    if (match_eval[0] == '+') {
+                        key.eval = 1001;
                     } else {
-                        key.score = -1001;
+                        key.eval = -1001;
                     }
 
                 } else {
-                    int score = 100 * fast_stof(match_score.data());
+                    int eval = 100 * fast_stof(match_eval.data());
 
-                    if (score > 1000) {
-                        score = 1000;
-                    } else if (score < -1000) {
-                        score = -1000;
+                    if (eval > 1000) {
+                        eval = 1000;
+                    } else if (eval < -1000) {
+                        eval = -1000;
                     }
 
-                    key.score = int(std::floor(score / 5.0)) * 5;  // reduce precision
+                    key.eval = int(std::floor(eval / 5.0)) * 5;  // reduce precision
                 }
             }
         }
 
-        if (key.score != 1002) {  // a score was found
-            key.outcome = board.sideToMove() == Color::WHITE ? resultkey.white : resultkey.black;
-            key.move    = board.fullMoveNumber();
+        if (key.eval != 1002) {  // an eval was found
+            key.result = board.sideToMove() == Color::WHITE ? resultkey.white : resultkey.black;
+            key.move   = board.fullMoveNumber();
             const auto knights = builtin::popcount(board.pieces(PieceType::KNIGHT));
             const auto bishops = builtin::popcount(board.pieces(PieceType::BISHOP));
             const auto rooks   = builtin::popcount(board.pieces(PieceType::ROOK));

--- a/scoreWDLstat.hpp
+++ b/scoreWDLstat.hpp
@@ -18,22 +18,22 @@ struct ResultKey {
 };
 
 struct Key {
-    Result outcome;             // game outcome from PoV of side to move
-    int move, material, score;  // move number, material count, engine's eval
+    Result result;             // game result from PoV of side to move
+    int move, material, eval;  // move number, material count, engine's eval
     bool operator==(const Key &k) const {
-        return outcome == k.outcome && move == k.move && material == k.material && score == k.score;
+        return result == k.result && move == k.move && material == k.material && eval == k.eval;
     }
     operator std::size_t() const {
         // golden ratio hashing, thus 0x9e3779b9
-        std::uint32_t hash = static_cast<int>(outcome);
+        std::uint32_t hash = static_cast<int>(result);
         hash ^= move + 0x9e3779b9 + (hash << 6) + (hash >> 2);
         hash ^= material + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-        hash ^= score + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+        hash ^= eval + 0x9e3779b9 + (hash << 6) + (hash >> 2);
         return hash;
     }
     operator std::string() const {
-        return "('" + std::string(1, static_cast<char>(outcome)) + "', " + std::to_string(move) +
-               ", " + std::to_string(material) + ", " + std::to_string(score) + ")";
+        return "('" + std::string(1, static_cast<char>(result)) + "', " + std::to_string(move) +
+               ", " + std::to_string(material) + ", " + std::to_string(eval) + ")";
     }
 };
 


### PR DESCRIPTION
This is a minor cleanup of the recent changes to the python script.

I also took the chance to make the variable names consistent with the readme, in particular now the name `score` is no longer ambiguous. 

Up to rounding errors the changes are non-functional for me.

PS: The rounding errors could be down to the change from `math.log` to `np.log`, but not sure.