### PR TITLE
speed up stable win rate computation

### DIFF
--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -167,22 +167,14 @@ class ModelFit:
         self.normalize_to_pawn_value = normalize_to_pawn_value
 
     @staticmethod
-    def win_rate(x, a, b):
-        def skip_overflow(arg):
-            if arg > 0:
-                return np.exp(-arg) / (1.0 + np.exp(-arg))
-            else:
-                return 1.0 / (1.0 + np.exp(arg))
+    def win_rate(x: float | np.ndarray, a, b):
+        def stable_logistic(z):
+            # returns 1 / (1 + exp(-z)) avoiding possible overflows
+            return np.where(
+                z < 0, np.exp(z) / (1.0 + np.exp(z)), 1.0 / (1.0 + np.exp(-z))
+            )
 
-        if type(x) == np.ndarray:
-            res = []
-            for xs in x:
-                arg = -(xs - a) / b
-                res.append(skip_overflow(arg))
-            return np.array(res)
-        else:
-            arg = -(x - a) / b
-            return skip_overflow(arg)
+        return stable_logistic((x - a) / b)
 
     @staticmethod
     def normalized_axis(ax, normalize_to_pawn_value: int):


### PR DESCRIPTION
To tell the truth, the speed up is less than I thought. But still a significant simplification.

No functional change.

Doing 
```
> python scoreWDL.py updateWDL.json --NormalizeData '{"yDataMin": 11, "yDataMax": 120, "yDataTarget": 32, "as": [0.38036525, -2.82015070, 23.17882135, 307.36768407]}' --plot save > master.txt
> diff master.txt patch.txt 
```
gives me 
```diff
17c17
< Total elapsed time = 58.67s.
---
> Total elapsed time = 55.55s.
```