### PR TITLE
change internal evals from float to int

### DIFF
--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -35,7 +35,7 @@ class WdlPlot:
 class ModelDataDensity:
     """Count data converted to densities"""
 
-    xs: list[int]  # internal evals in cp
+    xs: list[int]  # internal evals
     ys: list[int]  # moves or material
     zwins: list[float]  # corresponding win probability
     zdraws: list[float]  # draw prob

--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -106,7 +106,7 @@ class DataLoader:
 
             # convert the cp eval to the internal value
             if NormalizeToPawnValue is not None:
-                eval_internal = eval * NormalizeToPawnValue // 100
+                eval_internal = round(eval * NormalizeToPawnValue / 100)
             else:
                 yDataClamped = min(
                     max(yData, self.NormalizeData["yDataMin"]),
@@ -116,7 +116,7 @@ class DataLoader:
                     yDataClamped / self.NormalizeData["yDataTarget"],
                     *self.NormalizeData["as"],
                 )
-                eval_internal = eval * a // 100
+                eval_internal = round(eval * a / 100)
 
             if result == "W":
                 win[eval_internal, yData] += v

--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -88,7 +88,7 @@ class DataLoader:
         Counter[tuple[int, int]],
         int,
     ]:
-        """Extract three arrays, win draw and loss, counting positions with a given eval (float) and move/material (int) that are wdl"""
+        """Extract three arrays, win draw and loss, counting positions with a given eval (int) and move/material (int) that are wdl"""
         freq: Counter[tuple[str, int, int, int]] = Counter(
             {literal_eval(k): v for k, v in inputdata.items()}
         )

--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -35,7 +35,7 @@ class WdlPlot:
 class ModelDataDensity:
     """Count data converted to densities"""
 
-    xs: list[float]  # evals
+    xs: list[int]  # internal evals in cp
     ys: list[int]  # moves or material
     zwins: list[float]  # corresponding win probability
     zdraws: list[float]  # draw prob
@@ -83,18 +83,19 @@ class DataLoader:
         NormalizeData: str,
         yDataFormat: Literal["move", "material"],
     ) -> tuple[
-        Counter[tuple[float, int]],
-        Counter[tuple[float, int]],
-        Counter[tuple[float, int]],
+        Counter[tuple[int, int]],
+        Counter[tuple[int, int]],
+        Counter[tuple[int, int]],
+        int,
     ]:
         """Extract three arrays, win draw and loss, counting positions with a given eval (float) and move/material (int) that are wdl"""
         freq: Counter[tuple[str, int, int, int]] = Counter(
             {literal_eval(k): v for k, v in inputdata.items()}
         )
 
-        win: Counter[tuple[float, int]] = Counter()
-        draw: Counter[tuple[float, int]] = Counter()
-        loss: Counter[tuple[float, int]] = Counter()
+        win: Counter[tuple[int, int]] = Counter()
+        draw: Counter[tuple[int, int]] = Counter()
+        loss: Counter[tuple[int, int]] = Counter()
         # filter out (eval, yData) WDL data (i.e. material or move summed out)
         for (result, move, material, eval), v in freq.items():
             # exclude large evals and unwanted move numbers
@@ -105,7 +106,7 @@ class DataLoader:
 
             # convert the cp eval to the internal value
             if NormalizeToPawnValue is not None:
-                eval_internal = eval * NormalizeToPawnValue / 100
+                eval_internal = eval * NormalizeToPawnValue // 100
             else:
                 yDataClamped = min(
                     max(yData, self.NormalizeData["yDataMin"]),
@@ -115,7 +116,7 @@ class DataLoader:
                     yDataClamped / self.NormalizeData["yDataTarget"],
                     *self.NormalizeData["as"],
                 )
-                eval_internal = eval * a / 100
+                eval_internal = eval * a // 100
 
             if result == "W":
                 win[eval_internal, yData] += v
@@ -138,9 +139,9 @@ class DataLoader:
 
     def get_model_data_density(
         self,
-        win: Counter[tuple[float, int]],
-        draw: Counter[tuple[float, int]],
-        loss: Counter[tuple[float, int]],
+        win: Counter[tuple[int, int]],
+        draw: Counter[tuple[int, int]],
+        loss: Counter[tuple[int, int]],
     ) -> ModelDataDensity:
         """Turn the counts of positions into densities/frequencies
 
@@ -170,14 +171,14 @@ class ModelFit:
         self.normalize_to_pawn_value = normalize_to_pawn_value
 
     @staticmethod
-    def win_rate(x: float | np.ndarray, a, b):
+    def win_rate(eval: int | np.ndarray, a, b):
         def stable_logistic(z):
             # returns 1 / (1 + exp(-z)) avoiding possible overflows
             return np.where(
                 z < 0, np.exp(z) / (1.0 + np.exp(z)), 1.0 / (1.0 + np.exp(-z))
             )
 
-        return stable_logistic((x - a) / b)
+        return stable_logistic((eval - a) / b)
 
     @staticmethod
     def normalized_axis(ax, normalize_to_pawn_value: int):
@@ -206,7 +207,7 @@ class ModelFit:
 
     def wdl(
         self,
-        eval: float,
+        eval: int,
         move_or_material: int,
         popt_as: list[float],
         popt_bs: list[float],
@@ -316,7 +317,7 @@ class WdlModel:
         ywindata: list[float],
         ydrawdata: list[float],
         ylossdata: list[float],
-        popt_ab,
+        popt_ab: tuple[float, float],
     ):
         # plot sample curves at yDataTarget
         self.plot.axs[0, 0].plot(xdata, ywindata, "b.", label="Measured winrate")
@@ -344,17 +345,18 @@ class WdlModel:
 
     def extract_model_data(
         self,
-        xs: list[float],
+        xs: list[int],
         ys: list[int],
         zwins: list[float],
         zdraws: list[float],
         zlosses: list[float],
-        win: Counter[tuple[float, int]],
-        draw: Counter[tuple[float, int]],
-        loss: Counter[tuple[float, int]],
+        win: Counter[tuple[int, int]],
+        draw: Counter[tuple[int, int]],
+        loss: Counter[tuple[int, int]],
         fit,
         plotfunc: Callable[
-            [list[float], list[float], list[float], list[float], Any], None
+            [np.ndarray, list[float], list[float], list[float], tuple[float, float]],
+            None,
         ],
     ):
         evals, moms, winrate, drawrate, lossrate = xs, ys, zwins, zdraws, zlosses
@@ -395,9 +397,9 @@ class WdlModel:
 
             # get the subset of data relevant for this mom
             if self.args.modelFitting != "fitDensity":
-                winsubset: Counter[tuple[float, int]] = Counter()
-                drawsubset: Counter[tuple[float, int]] = Counter()
-                losssubset: Counter[tuple[float, int]] = Counter()
+                winsubset: Counter[tuple[int, int]] = Counter()
+                drawsubset: Counter[tuple[int, int]] = Counter()
+                losssubset: Counter[tuple[int, int]] = Counter()
                 for (eval, momkey), count in win.items():
                     if momkey < mmin or momkey >= mmax:
                         continue
@@ -445,14 +447,14 @@ class WdlModel:
 
     def fit_model(
         self,
-        xs: list[float],
+        xs: list[int],
         ys: list[int],
         zwins: list[float],
         zdraws: list[float],
         zlosses: list[float],
-        win: Counter[tuple[float, int]],
-        draw: Counter[tuple[float, int]],
-        loss: Counter[tuple[float, int]],
+        win: Counter[tuple[int, int]],
+        draw: Counter[tuple[int, int]],
+        loss: Counter[tuple[int, int]],
     ) -> ModelData:
         print(f"Fit WDL model based on {self.args.yData}.")
         #
@@ -830,7 +832,7 @@ if __name__ == "__main__":
             loss,
         )
         if args.modelFitting != "None"
-        else ModelData([], [], [], [], [], "", "")
+        else ModelData([], [], np.asarray([]), [], [], "", "")
     )
 
     if args.plot != "no":


### PR DESCRIPTION
This PR might need some discussion before merging.

It changes the current float type for the denormalized internal evals from `float` to `int`. I believe this is more transparent, as these were integers in the engine as well. Moreover, defining them as `int` _may_ open the door to some code optimizations in future, were the 2D data is treating as NumPy 2D arrays, or as SciPy sparse matrices or similar.

The patch is, of course, functional. But only to the extend of the rounding errors from the denormalization. One could maybe argue that the new `int` values are likely closer to the true engine evals than master.

Tested with e.g.
```
> python scoreWDL.py --plot save > master.txt
> diff master.txt patch.txt 
```
to give
```diff
13,14c13,14
< Corresponding normalized spread = 0.17835720039691905;
< Draw rate at 0.0 eval at move 32 = 0.9926807354652202;
---
> Corresponding normalized spread = 0.17856650002022897;
> Draw rate at 0.0 eval at move 32 = 0.9926326548171064;
16,19c16,19
< as = ((1.299 * x / 32 + -5.882) * x / 32 + 16.667) * x / 32 + 323.489
< bs = ((-5.234 * x / 32 + 34.269) * x / 32 + -59.104) * x / 32 + 89.922
<      constexpr double as[] = {   1.29908560,   -5.88159256,   16.66748436,  323.48933024};
<      constexpr double bs[] = {  -5.23429378,   34.26855185,  -59.10404312,   89.92187908 };
---
> as = ((1.297 * x / 32 + -5.871) * x / 32 + 16.652) * x / 32 + 323.096
> bs = ((-5.234 * x / 32 + 34.268) * x / 32 + -59.102) * x / 32 + 89.919
>      constexpr double as[] = {   1.29719238,   -5.87132266,   16.65160741,  323.09634761};
>      constexpr double bs[] = {  -5.23434226,   34.26822898,  -59.10192983,   89.91885990 };
23c23
< Total elapsed time = 20.48s.
---
> Total elapsed time = 20.45s.
```
