### PR TITLE
simplification: change wdl tuple to probabilities

### DIFF
--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -26,14 +26,14 @@ def model_wdl_tuple(
     mom_target: int,
     popt_as: list[float],
     popt_bs: list[float],
-) -> tuple[int, int, int]:
-    """our wdl model is based on win_rate() with a and p polynomials in mom,
+) -> tuple[float, float, float]:
+    """our wdl model is based on win_rate() with a and b polynomials in mom,
     where mom = move or material counter"""
     a = poly3(mom / mom_target, *popt_as)
     b = poly3(mom / mom_target, *popt_bs)
-    w = int(1000 * win_rate(eval, a, b))
-    l = int(1000 * win_rate(-eval, a, b))
-    return w, 1000 - w - l, l
+    w = win_rate(eval, a, b)
+    l = win_rate(-eval, a, b)
+    return w, 1 - w - l, l
 
 
 class WdlPlot:
@@ -641,7 +641,6 @@ class WdlModel:
                         model.popt_as,
                         model.popt_bs,
                     )[0]
-                    / 1000.0
                 )
             zz = griddata(points, zwins, (grid_x, grid_y), method="linear")
             cp = self.plot.axs[1, 1].contourf(grid_x, grid_y, zz, contourlines)
@@ -684,7 +683,6 @@ class WdlModel:
                         model.popt_as,
                         model.popt_bs,
                     )[1]
-                    / 1000.0
                 )
             zz = griddata(points, zwins, (grid_x, grid_y), method="linear")
             cp = self.plot.axs[1, 2].contourf(grid_x, grid_y, zz, contourlines)


### PR DESCRIPTION
I guess the original function was used (also) in different contexts? @vondele  But now we can just treat wdl as probabilites. Surprisingly, the text output for my tests remains unchanged, even though the slightly functional nature of the PR means the png file changes slightly.