### PR TITLE
make probd calculations consistent

### DIFF
--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -291,7 +291,7 @@ class ObjectiveFunctions:
             a, b = self.get_ab(asbs, mom)
             probw = win_rate(eval, a, b)
             probl = win_rate(-eval, a, b)
-            prob = 1 - (probw + probl)
+            prob = 1 - probw - probl
             evalLogProb += count * np.log(max(prob, 1e-14))
 
         for (eval, mom), count in self.loss.items():


### PR DESCRIPTION
Now all consistent:

```
> grep "1 -" scoreWDL.py
    return w, 1 - w - l, l
        probd = 1 - probw - probl
            prob = 1 - probw - probl
        self.plot.axs[0, 0].plot(xdata, 1 - winmodel - lossmodel, "r-")
            f"Draw rate at 0.0 eval at move {self.yDataTarget} = {1 - 2 / (1 + np.exp(fsum_a / fsum_b))};"
```

The only reason I put this micro edit into a separate PR is that (funnily enough) this is functional. :)