### PR TITLE
deal with unphysical parameters centrally

### DIFF
--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -12,7 +12,8 @@ def win_rate(eval: int | np.ndarray, a, b):
         # returns 1 / (1 + exp(-z)) avoiding possible overflows
         return np.where(z < 0, np.exp(z) / (1.0 + np.exp(z)), 1.0 / (1.0 + np.exp(-z)))
 
-    # guard against unphysical values
+    # guard against unphysical values, treating small and negative values as 0
+    # during optimizations this will guide b (back) towards positive values
     if b < 1e-8:
         return np.where(eval - a < 0, 0, 1)
 

--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -12,6 +12,10 @@ def win_rate(eval: int | np.ndarray, a, b):
         # returns 1 / (1 + exp(-z)) avoiding possible overflows
         return np.where(z < 0, np.exp(z) / (1.0 + np.exp(z)), 1.0 / (1.0 + np.exp(-z)))
 
+    # guard against unphysical values
+    if b < 1e-8:
+        return np.where(eval - a < 0, 0, 1)
+
     return stable_logistic((eval - a) / b)
 
 
@@ -254,11 +258,6 @@ class ObjectiveFunctions:
         """Estimate game score based on probability of WDL"""
 
         a, b = self.get_ab(asbs, mom)
-
-        # guard against unphysical stuff
-        if a <= 0 or b <= 0:
-            return 4
-
         probw = win_rate(eval, a, b)
         probl = win_rate(-eval, a, b)
         probd = 1 - probw - probl


### PR DESCRIPTION
I think the model optimizations will avoid a<=0 naturally, so this PR only deals with b <= 0. Here as an extra guard we also check for b < 10^{-8}, and if so set the win rate to 0 or 1, depending on the sign of the argument.

I cannot test this for "degenerate" data, which may have necessitated the original safeguard in the first place. So feedback/tests by @vondele would be appreciated. In my tests the PR is nonfunctional.