### PR TITLE
use round not trunc for NormalizeToPawnValue

### DIFF
--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -48,7 +48,7 @@ class WdlData:
         if self.NormalizeData is not None:
             self.NormalizeData = json.loads(self.NormalizeData)
             self.NormalizeData["as"] = [float(x) for x in self.NormalizeData["as"]]
-            self.normalize_to_pawn_value = int(sum(self.NormalizeData["as"]))
+            self.normalize_to_pawn_value = int(sum(self.NormalizeData["as"]) + 0.5)
         else:
             self.normalize_to_pawn_value = args.NormalizeToPawnValue
 
@@ -367,11 +367,11 @@ class WdlModel:
         # now we can report the new conversion factor p_a from internal eval to centipawn
         # such that an expected win score of 50% is for an internal eval of p_a(mom)
         # for a static conversion (independent of mom), we provide a constant value
-        # NormalizeToPawnValue = int(p_a(yDataTarget)) = int(sum(coeffs_a))
+        # NormalizeToPawnValue = round(p_a(yDataTarget)) = round(sum(coeffs_a))
         fsum_a, fsum_b = sum(self.coeffs_a), sum(self.coeffs_b)
 
-        print(f"const int NormalizeToPawnValue = {int(fsum_a)};")
-        print(f"Corresponding spread = {int(fsum_b)};")
+        print(f"const int NormalizeToPawnValue = {int(fsum_a + 0.5)};")
+        print(f"Corresponding spread = {int(fsum_b + 0.5)};")
         print(f"Corresponding normalized spread = {fsum_b / fsum_a};")
         print(
             f"Draw rate at 0.0 eval at move {self.yDataTarget} = {1 - 2 / (1 + np.exp(fsum_a / fsum_b))};"


### PR DESCRIPTION
I believe rounding is the more correct approach. In the extreme case, in master a value like `328.9` is truncated to `328`.

**Important note**: Requires a corresponding fix to the `static_assert` in stockfish code with the next WDL update, and similarly for other engines that use this repo for their internal WDL model and have the same assert as stockfish.

Example:
```
> cat master.txt
Converting evals with NormalizeToPawnValue = 328.
Reading eval stats from scoreWDLstat.json.
Retained (W,D,L) = (6872929, 16756625, 6971320) positions.
Fit WDL model based on move.
Warning: Too little data for move value 3, skip fitting.
Warning: Too little data for move value 4, skip fitting.
Warning: Too little data for move value 5, skip fitting.
Warning: Too little data for move value 6, skip fitting.
Warning: Too little data for move value 7, skip fitting.
Warning: Too little data for move value 8, skip fitting.
const int NormalizeToPawnValue = 335;
Corresponding spread = 59;
Corresponding normalized spread = 0.17836150742509121;
Draw rate at 0.0 eval at move 32 = 0.9926797480716687;
Parameters in internal value units: 
as = ((1.301 * x / 32 + -5.890) * x / 32 + 16.682) * x / 32 + 323.482
bs = ((-5.234 * x / 32 + 34.269) * x / 32 + -59.107) * x / 32 + 89.926
     constexpr double as[] = {   1.30054473,   -5.89004449,   16.68220601,  323.48160643};
     constexpr double bs[] = {  -5.23424726,   34.26935139,  -59.10734356,   89.92577969 };
Preparing contour plots and plots of model parameters.
Saved graphics to scoreWDL.png.
```

`diff master.txt patch.txt`:
```diff
11,12c11,12
< const int NormalizeToPawnValue = 335;
< Corresponding spread = 59;
---
> const int NormalizeToPawnValue = 336;
> Corresponding spread = 60;
```

