### PR TITLE
output coefficients in clang format

### DIFF
--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -380,7 +380,7 @@ class WdlModel:
         print("Parameters in internal value units: ")
         print(self.label_p_a + "\n" + self.label_p_b)
         for ab, coeffs in [("a", self.coeffs_a), ("b", self.coeffs_b)]:
-            cstr = ", ".join([f"{c:13.8f}" for c in coeffs])
+            cstr = ", ".join([f"{c:.8f}" for c in coeffs])
             print(f"     constexpr double {ab}s[] = {{{cstr}}};")
 
 

--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -379,14 +379,11 @@ class WdlModel:
 
         print("Parameters in internal value units: ")
         print(self.label_p_a + "\n" + self.label_p_b)
-        print(
-            "     constexpr double as[] = {%13.8f, %13.8f, %13.8f, %13.8f};"
-            % tuple(self.coeffs_a)
-        )
-        print(
-            "     constexpr double bs[] = {%13.8f, %13.8f, %13.8f, %13.8f };"
-            % tuple(self.coeffs_b)
-        )
+        for ab, coeffs in [("a", tuple(self.coeffs_a)), ("b", tuple(self.coeffs_b))]:
+            print(
+                f"     constexpr double {ab}s[] = {{%13.8f, %13.8f, %13.8f, %13.8f}};"
+                % coeffs
+            )
 
 
 class WdlPlot:

--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -379,11 +379,9 @@ class WdlModel:
 
         print("Parameters in internal value units: ")
         print(self.label_p_a + "\n" + self.label_p_b)
-        for ab, coeffs in [("a", tuple(self.coeffs_a)), ("b", tuple(self.coeffs_b))]:
-            print(
-                f"     constexpr double {ab}s[] = {{%13.8f, %13.8f, %13.8f, %13.8f}};"
-                % coeffs
-            )
+        for ab, coeffs in [("a", self.coeffs_a), ("b", self.coeffs_b)]:
+            cstr = ", ".join([f"{c:13.8f}" for c in coeffs])
+            print(f"     constexpr double {ab}s[] = {{{cstr}}};")
 
 
 class WdlPlot:

--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -381,7 +381,7 @@ class WdlModel:
         print(self.label_p_a + "\n" + self.label_p_b)
         for ab, coeffs in [("a", self.coeffs_a), ("b", self.coeffs_b)]:
             cstr = ", ".join([f"{c:.8f}" for c in coeffs])
-            print(f"     constexpr double {ab}s[] = {{{cstr}}};")
+            print(f"   constexpr double {ab}s[] = {{{cstr}}};")
 
 
 class WdlPlot:


### PR DESCRIPTION
Master has a rogue white space in the printed list of `bs` coefficients. PR removes that and also simplifies the code.

No functional change.