### PR TITLE
set default --materialMax to 78

### DIFF
--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -589,7 +589,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--materialMax",
         type=int,
-        default=120,
+        default=78,
         help="Upper material count limit for filter applied to json data.",
     )
     parser.add_argument(


### PR DESCRIPTION
This is a left-over change from https://github.com/official-stockfish/WDL_model/pull/146, and sets the default value for `--materialMax` to the material count of the starting position.

As this could potentially also affect the fitting by move (due to the filter applied to the json data), merging this PR should await approval by @vondele. (Basically in master hardly any position will be filtered based on material count, whereas this PR may filter some games with very early promotions, but I think that is highly unlikely.)