### PR TITLE
enable dynamic renormalization in updateWDL.sh

### DIFF
--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -53,6 +53,10 @@ class WdlData:
             self.normalize_to_pawn_value = int(sum(self.NormalizeData["as"]))
             if not "momType" in self.NormalizeData:
                 self.NormalizeData["momType"] = "move"
+            assert self.NormalizeData["momType"] in [
+                "move",
+                "material",
+            ], "Error: momType must be move or material."
         else:
             self.normalize_to_pawn_value = args.NormalizeToPawnValue
 

--- a/updateWDL.sh
+++ b/updateWDL.sh
@@ -117,6 +117,10 @@ get_normalize_data() {
     local pawn=$(git grep 'const int NormalizeToPawnValue' "$revision" -- src/uci.h | grep -oP 'const int NormalizeToPawnValue = \K\d+')
 
     if [ -z "$pawn" ]; then
+        pawn=$(git grep 'constexpr int  NormalizeToPawnValue' "$revision" -- src/uci.cpp | grep -oP 'constexpr int  NormalizeToPawnValue = \K\d+')
+    fi
+
+    if [ -z "$pawn" ]; then
         line=$(git grep 'double m = std::clamp(ply / 2 + 1' "$revision" -- src/uci.cpp)
 
         momMin="${line#*std::clamp(ply / 2 + 1, }"


### PR DESCRIPTION
This PR prepares the update script for the future, when https://github.com/official-stockfish/Stockfish/pull/4920 will be merged into SF.

Some comments:
- The PR relies on `NormalizeToPawnValue` *not* being present in `src/uci.h` for SF revisions that do the dynamic eval rescaling. Edit: It now relies on `const in NormalizeToPawnValue` not being present in `src/uci.h` and `constexpr int  NormalizeToPawnValue` not being present in `src/uci.cpp`.
- For those revisions, the corresponding value of `NormalizeToPawnValue` is computed on the fly, by summing the coefficients in `as`. The final sum is *rounded*, so that after merging https://github.com/official-stockfish/WDL_model/pull/136 this will be consistent with the python script. Note also that for un-doing the dynamic rescaling, the value `NormalizeToPawnValue` serves only a cosmetic purpose now. It is used at the end of the update script to indicate to the user if that value has changed from SF to the new model, or not.
- If this new update script is called with the same sha for `--firstrev` and `--lastrev` it allows for extracting the newly fitted `NormalizeToPawnValue` for both static and dynamic renormalization revisions of SF. This may be useful when adapting https://github.com/official-stockfish/WDL_model/pull/119

For as long as https://github.com/official-stockfish/Stockfish/pull/4920 is not merged into SF, this PR is nonfunctional. Once that PR is merged, the update script needs to be pointed to that new commit in `default_firstrev`, and it should then seamlessly work for the dynamic eval rescalings.