### PR TITLE
accept pgn's from openbench

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -158,7 +158,8 @@ class Analyze : public pgn::Visitor {
             return;
         }
 
-        const size_t delimiter_pos = comment.find('/');
+        // openbench uses Nf3 {+0.57 17/28 583 363004}, fishtest Nf3 {+0.57/17}
+        const size_t delimiter_pos = comment.find_first_of(" /");
 
         Key key;
         key.eval = 1002;


### PR DESCRIPTION
The PGNs from openbench have the format
```
1. Nf3 {+0.57 17/28 583 363004} Na6 {-0.57 17/22 520 671767}
```
whereas the fishtest PGNs look like
```
1. Nf3 {+0.92/22 5.7s} Bc5 {-0.92/28 33s} 2. Rg1 {+1.16/21 2.2s}
```

We can easily accept both kinds of data by allowing both `/` and ` ` as delimiter for the centipawn evaluation in the comment string.

No functional change for fishtest data.