### PR TITLE
fix treatment of ep square with --fixFENsource

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -86,12 +86,12 @@ class Analyze : public pgn::Visitor {
 
     void header(std::string_view key, std::string_view value) override {
         if (key == "FEN") {
-            std::regex p("^(.+) (.+) 0 1$");
+            std::regex p("^(.+) 0 1$");
             std::smatch match;
             std::string value_str(value);
 
-            // revert changes by cutechess-cli to move counters, but trust it on ep square
-            if (!fixfen_map.empty() && std::regex_search(value_str, match, p) && match.size() > 2) {
+            // revert changes by cutechess-cli to move counters
+            if (!fixfen_map.empty() && std::regex_search(value_str, match, p) && match.size() > 1) {
                 std::string fen = match[1];
                 auto it         = fixfen_map.find(fen);
 
@@ -100,10 +100,9 @@ class Analyze : public pgn::Visitor {
                     std::exit(1);
                 }
 
-                const auto &fix         = it->second;
-                std::string ep          = match[2];  // trust cutechess-cli on this one
-                std::string fixed_value = fen + " " + ep + " " + std::to_string(fix.first) + " " +
-                                          std::to_string(fix.second);
+                const auto &fix = it->second;
+                std::string fixed_value =
+                    fen + " " + std::to_string(fix.first) + " " + std::to_string(fix.second);
                 board.setFen(fixed_value);
             } else {
                 board.setFen(value);
@@ -294,7 +293,7 @@ void ana_files(const std::vector<std::string> &files, const std::string &regex_e
 
             if (!fullmove) continue;
 
-            auto key         = f1 + ' ' + f2 + ' ' + f3;
+            auto key         = f1 + ' ' + f2 + ' ' + f3 + ' ' + ep;
             auto fixfen_data = std::pair<int, int>(halfmove, fullmove);
 
             if (fixfen_map.find(key) != fixfen_map.end()) {


### PR DESCRIPTION
This PR applies the patch from https://github.com/Disservin/ana-opening-book/pull/6.

Our current book contains exits that differ only in the ep square, e.g.

```
grep "r1bqk1nr/pp2b1pp/2n1p3/2ppPp2/3P4/5N2/PPP1NPPP/R1BQKB1R w KQkq" UHO_Lichess_4852_v1.epd
r1bqk1nr/pp2b1pp/2n1p3/2ppPp2/3P4/5N2/PPP1NPPP/R1BQKB1R w KQkq - 2 9
r1bqk1nr/pp2b1pp/2n1p3/2ppPp2/3P4/5N2/PPP1NPPP/R1BQKB1R w KQkq f6 0 7
```

In master this means that if a game is found with the first FEN, the move counter will be changed to `0 7`, as master prefers lower full move counters when the first three FEN fields are equal. This then means that over a mixture
of games, the first FEN may appear with move counters `0 7` and `2 9`, which was undesirable in the repo https://github.com/Disservin/ana-opening-book, for example.

For the wdl repo the effect is only minor, but it is still good programming practice to fix it, imo.

Since cutechess-cli omits superfluous ep squares, `scoreWDLstat` may exit with an error when the so amended FEN cannot be found in the book provided through `--fixFENsource`. However, on correcting the .epd file appropriately
this can be easily overcome.