### PR TITLE
catch all unnatural terminations

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -133,7 +133,8 @@ class Analyze : public pgn::Visitor {
         }
 
         if (key == "Termination") {
-            if (value == "time forfeit" || value == "abandoned") {
+            if (value == "time forfeit" || value == "abandoned" || value == "stalled connection" ||
+                value == "illegal move" || value == "unterminated") {
                 goodTermination = false;
             }
         }


### PR DESCRIPTION
An example where "stalled connection" appeared is in `3-12-09/6573b57df09ce1261f1231bc/6573b57df09ce1261f1231bc-84.pgn.gz`.

The PR should now catch all possible cases, see https://github.com/cutechess/cutechess/blob/1071d84cf272bd7deca0964336bf02e367e2b22b/projects/lib/src/pgngame.cpp#L470