### PR TITLE
in plots of p_a and p_b also show old p_a, if available

### DIFF
--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -498,14 +498,29 @@ class WdlPlot:
             self.axs[1, 0].plot(
                 model.ms,
                 poly3(model.ms / model.momTarget, *model.coeffs_a),
-                "r-",
+                color="red",
+                linewidth=2,
                 label=model.label_p_a,
             )
+            if (
+                wdl_data.NormalizeData is not None
+                and wdl_data.NormalizeData["momType"] == wdl_data.momType
+            ):
+                self.axs[1, 0].plot(
+                    model.ms,
+                    poly3(
+                        model.ms / wdl_data.NormalizeData["momTarget"],
+                        *wdl_data.NormalizeData["as"],
+                    ),
+                    color="lightcoral",
+                    linestyle="dashed",
+                    label="p_a (old model)",
+                )
             self.axs[1, 0].plot(model.ms, model.bs, "g.", label="bs")
             self.axs[1, 0].plot(
                 model.ms,
                 poly3(model.ms / model.momTarget, *model.coeffs_b),
-                "m-",
+                color="magenta",
                 label=model.label_p_b,
             )
 

--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -514,7 +514,7 @@ class WdlPlot:
                     ),
                     color="lightcoral",
                     linestyle="dashed",
-                    label="p_a (old model)",
+                    label="p_a of the input data's model",
                 )
             self.axs[1, 0].plot(model.ms, model.bs, "g.", label="bs")
             self.axs[1, 0].plot(


### PR DESCRIPTION
This is now possible, if old and new model used the same `momType`.

I made new `p_a` bold, and old `p_a` dashed with a lighter red. Can easily be changed, ofc.