### PR TITLE
download script: break on errors

### DIFF
--- a/download_fishtest_pgns.py
+++ b/download_fishtest_pgns.py
@@ -123,12 +123,16 @@ while True:
             ]
     except urllib.error.HTTPError as ex:
         print(f"HTTP Error: {ex.code} - {ex.reason}")
+        break
     except urllib.error.URLError as ex:
         print(f"URL Error: {ex.reason}")
+        break
     except json.JSONDecodeError as ex:
         print(f"JSON Decoding Error: {ex}")
+        break
     except Exception as ex:
         print(f"Error: {ex}")
+        break
 
     # download .pgn.tar ball for each test
     for test, dateStr, meta in ids:


### PR DESCRIPTION
master:
```
Found 483 downloaded tests in ./pgns/ already.
Error: unconverted data remains: +00:00
Traceback (most recent call last):
  File "/home/rn/git/wdl_model/download_fishtest_pgns.py", line 134, in <module>
    for test, dateStr, meta in ids:
NameError: name 'ids' is not defined. Did you mean: 'id'?
```

patch:
```
Found 483 downloaded tests in ./pgns/ already.
Error: unconverted data remains: +00:00
Finished downloading PGNs.
```