### PR TITLE
fix error in start_time parsing

### DIFF
--- a/download_fishtest_pgns.py
+++ b/download_fishtest_pgns.py
@@ -113,8 +113,8 @@ while True:
             ids = [
                 (
                     id,
-                    datetime.datetime.strptime(
-                        response_json[id]["start_time"], "%Y-%m-%d %H:%M:%S.%f"
+                    datetime.datetime.fromisoformat(
+                        response_json[id]["start_time"]
                     ).strftime("%y-%m-%d"),
                     response_json[id],
                 )


### PR DESCRIPTION
The recent fishtest commit https://github.com/official-stockfish/fishtest/commit/c7d7d6f46a3fb72c9eccd408dd0b95267af9586f breaks our current `start_time` parsing in the download script.

The patch replaces the string-based parsing with the more robust `datetime.fromisoformat`.