### PR TITLE
check for Content-Length in header response

### DIFF
--- a/download_fishtest_pgns.py
+++ b/download_fishtest_pgns.py
@@ -163,9 +163,8 @@ while True:
         url = "https://tests.stockfishchess.org/api/run_pgns/" + test + ".pgn.gz"
         try:
             response = urllib.request.urlopen(url)
-            b = ""  # FIXME
-            # b = int(response.getheader("Content-Length"))
-            # b = "" if b is None else format_large_number(b) + "B "
+            b = response.getheader("Content-Length", None)
+            b = "" if b is None else format_large_number(int(b)) + "B "
             msg = f"Downloading {b}.pgn.gz file "
             if games is not None:
                 msg += f"with {games} games {'' if args.verbose == 0 else f'(WDL = {wins} {draws} {losses}) '}"


### PR DESCRIPTION
I believe this is the best way to deal with current situation, while being ready for a possible re-addition of the info to the header from the fishtest side.