### PR TITLE
only count games with a defined result

### DIFF
--- a/download_fishtest_pgns.py
+++ b/download_fishtest_pgns.py
@@ -21,7 +21,8 @@ def count_games(filename):
     with open_file_rt(filename) as f:
         for line in f:
             if "Result" in line:
-                count += 1
+                if "1-0" in line or "0-1" in line or "1/2-1/2" in line:
+                    count += 1
     return count
 
 


### PR DESCRIPTION
The PGN's may contain games that have not terminated with a result.
```
> zcat pgns/24-04-29/662faee73a05f1bf7a5113c1/662faee73a05f1bf7a5113c1.pgn.gz | grep Result | sort -u
[Result "*"]
[Result "0-1"]
[Result "1-0"]
[Result "1/2-1/2"]
```

So this PR only counts win, losses and draws. Note that also with this patch, some fishtest data have too few, and some have to many games.
```
> python download_fishtest_pgns.py -v
Found 30 downloaded tests in ./pgns/ already.
Collecting meta data for test 6630386a3a05f1bf7a511b23 ...
Downloading 11MB .pgn.gz file with 10626 games (WDL = 2671 5295 2660) to ./pgns/24-04-30/6630386a3a05f1bf7a511b23/ ...
Download completed. The file contains 10667 games. I.e. 41 more than expected.
Collecting meta data for test 663038593a05f1bf7a511b20 ...
Downloading 8MB .pgn.gz file with 7278 games (WDL = 1814 3598 1866) to ./pgns/24-04-30/663038593a05f1bf7a511b20/ ...
Download completed. The file contains 7310 games. I.e. 32 more than expected.
Collecting meta data for test 662facb93a05f1bf7a511397 ...
Downloading 22MB .pgn.gz file with 21228 games (WDL = 5345 10541 5342) to ./pgns/24-04-29/662facb93a05f1bf7a511397/ ...
Download completed. The file contains 20976 games. I.e. 252 fewer than expected.
```