### PR TITLE
allow filtering of .pgn file by time control

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -446,6 +446,26 @@ class TcFilterStrategy {
     }
 };
 
+class ThreadsFilterStrategy {
+    int threads;
+
+   public:
+    ThreadsFilterStrategy(int t) : threads(t) {}
+
+    bool apply(const std::string &filename, const map_meta &meta_map) const {
+        if (meta_map.find(filename) == meta_map.end()) {
+            return true;
+        }
+
+        if (meta_map.at(filename).threads.has_value() &&
+            meta_map.at(filename).threads.value() == threads) {
+            return false;
+        }
+
+        return true;
+    }
+};
+
 class SprtFilterStrategy {
    public:
     bool apply(const std::string &filename, const map_meta &meta_map) const {
@@ -536,6 +556,7 @@ void print_usage(char const *program_name) {
     ss << "  --matchRev <regex>    Filter data based on revision SHA in metadata" << "\n";
     ss << "  --matchEngine <regex> Filter data based on engine name in pgns, defaults to matchRev if given" << "\n";
     ss << "  --matchTC <regex>     Filter data based on time control in metadata" << "\n";
+    ss << "  --matchThreads <N>    Filter data based on used threads in metadata" << "\n";
     ss << "  --matchBook <regex>   Filter data based on book name in metadata" << "\n";
     ss << "  --matchBookInvert     Invert the filter" << "\n";
     ss << "  --SPRTonly            Analyse only pgns from SPRT tests" << "\n";
@@ -648,6 +669,13 @@ int main(int argc, char const *argv[]) {
             std::cout << "Filtering pgn files matching TC " << regex_tc << std::endl;
             filter_files(files_pgn, meta_map, TcFilterStrategy(std::regex(regex_tc)));
         }
+    }
+
+    if (cmd.has_argument("--matchThreads")) {
+        int threads = std::stoi(cmd.get_argument("--matchThreads"));
+
+        std::cout << "Filtering pgn files using threads = " << threads << std::endl;
+        filter_files(files_pgn, meta_map, ThreadsFilterStrategy(threads));
     }
 
     if (cmd.has_argument("--fixFENsource")) {

--- a/scoreWDLstat.hpp
+++ b/scoreWDLstat.hpp
@@ -50,7 +50,7 @@ struct std::equal_to<Key> {
 };
 
 struct TestMetaData {
-    std::optional<std::string> book, resolved_base, resolved_new;
+    std::optional<std::string> book, new_tc, resolved_base, resolved_new, tc;
     std::optional<bool> sprt;
 };
 
@@ -70,8 +70,10 @@ void from_json(const nlohmann::json &nlohmann_json_j, TestMetaData &nlohmann_jso
     nlohmann_json_t.sprt = j.contains("sprt") ? std::optional<bool>(true) : std::nullopt;
 
     nlohmann_json_t.book          = get_optional(j, "book");
+    nlohmann_json_t.new_tc        = get_optional(j, "new_tc");
     nlohmann_json_t.resolved_base = get_optional(j, "resolved_base");
     nlohmann_json_t.resolved_new  = get_optional(j, "resolved_new");
+    nlohmann_json_t.tc            = get_optional(j, "tc");
 }
 
 /// @brief Custom stof implementation to avoid locale issues, once clang supports std::from_chars

--- a/scoreWDLstat.hpp
+++ b/scoreWDLstat.hpp
@@ -51,6 +51,7 @@ struct std::equal_to<Key> {
 
 struct TestMetaData {
     std::optional<std::string> book, new_tc, resolved_base, resolved_new, tc;
+    std::optional<int> threads;
     std::optional<bool> sprt;
 };
 
@@ -74,6 +75,7 @@ void from_json(const nlohmann::json &nlohmann_json_j, TestMetaData &nlohmann_jso
     nlohmann_json_t.resolved_base = get_optional(j, "resolved_base");
     nlohmann_json_t.resolved_new  = get_optional(j, "resolved_new");
     nlohmann_json_t.tc            = get_optional(j, "tc");
+    nlohmann_json_t.threads       = get_optional<int>(j, "threads");
 }
 
 /// @brief Custom stof implementation to avoid locale issues, once clang supports std::from_chars

--- a/updateWDL.sh
+++ b/updateWDL.sh
@@ -164,7 +164,7 @@ echo "Look recursively in directory $pgnpath for games from SPRT tests using" \
     "$oldepoch) and $lastrev (from $newepoch)."
 
 # obtain the WDL data from games of SPRT tests of the SF revisions of interest
-./scoreWDLstat --dir $pgnpath -r --matchRev $regex_pattern --matchBook "$bookname" --fixFENsource "$fixfen.gz" --SPRTonly -o updateWDL.json >&scoreWDLstat.log
+./scoreWDLstat --dir $pgnpath -r --matchTC "60\+0.6" --matchRev $regex_pattern --matchBook "$bookname" --fixFENsource "$fixfen.gz" --SPRTonly -o updateWDL.json >&scoreWDLstat.log
 
 gamescount=$(grep -o '[0-9]\+ games' scoreWDLstat.log | grep -o '[0-9]\+')
 

--- a/updateWDL.sh
+++ b/updateWDL.sh
@@ -164,7 +164,7 @@ echo "Look recursively in directory $pgnpath for games from SPRT tests using" \
     "$oldepoch) and $lastrev (from $newepoch)."
 
 # obtain the WDL data from games of SPRT tests of the SF revisions of interest
-./scoreWDLstat --dir $pgnpath -r --matchTC "60\+0.6" --matchRev $regex_pattern --matchBook "$bookname" --fixFENsource "$fixfen.gz" --SPRTonly -o updateWDL.json >&scoreWDLstat.log
+./scoreWDLstat --dir $pgnpath -r --matchTC "60\+0.6" --matchThreads 1 --matchRev $regex_pattern --matchBook "$bookname" --fixFENsource "$fixfen.gz" --SPRTonly -o updateWDL.json >&scoreWDLstat.log
 
 gamescount=$(grep -o '[0-9]\+ games' scoreWDLstat.log | grep -o '[0-9]\+')
 


### PR DESCRIPTION
This PR allows to filter the PGN's to be analysed by the used TC. 

Also restrict the TC to "60+0.6" for the update script.

Example usage:

```
> ./scoreWDLstat -r
Looking (recursively) for pgn files in ./pgns
Found 289 .pgn(.gz) files in total.
Found 289 .pgn(.gz) files, creating 29 chunks for processing.
Progress: 29/29
Time taken: 143.412s
Wrote 469199126 scored positions from 3537103 games to scoreWDLstat.json for analysis.
```

```
> ./scoreWDLstat -r --matchTC "60\+0.6"
Looking (recursively) for pgn files in ./pgns
Found 289 .pgn(.gz) files in total.
Filtering pgn files matching TC 60\+0.6
Found 287 .pgn(.gz) files, creating 32 chunks for processing.
Progress: 32/32
Time taken: 161.762s
Wrote 456593122 scored positions from 3445831 games to scoreWDLstat.json for analysis.
```

```
> ./scoreWDLstat -r --matchTC "180.*"
Looking (recursively) for pgn files in ./pgns
Found 289 .pgn(.gz) files in total.
Filtering pgn files matching TC 180.*
Found 1 .pgn(.gz) files, creating 1 chunks for processing.
Progress: 1/1
Time taken: 7.771s
Wrote 7556380 scored positions from 54970 games to scoreWDLstat.json for analysis.
```