### PR TITLE
increase default materialMin to 17

### DIFF
--- a/scoreWDL.py
+++ b/scoreWDL.py
@@ -637,7 +637,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--materialMin",
         type=int,
-        default=10,
+        default=17,
         help="Lower material count limit for filter applied to json data.",
     )
     parser.add_argument(

--- a/updateWDL.sh
+++ b/updateWDL.sh
@@ -7,7 +7,7 @@ set -e
 # by default we start from the most recent WDL model change and go to master
 default_firstrev=6fc7da44ad9c7e2ba6062d5c79daafd29a4dcd6f
 default_lastrev=HEAD
-default_materialMin=10
+default_materialMin=17
 firstrev=$default_firstrev
 lastrev=$default_lastrev
 materialMin=$default_materialMin


### PR DESCRIPTION
As per the plots and discussion on [discord](https://discord.com/channels/435943710472011776/900771437177094156/1242729158057005158), it was decided it is probably best to increase the lower limit for our material count data from 10 to 17.

At low material count values the data is likely too sparse to create meaningful fits. 

Plots of master vs patch below.
![master](https://github.com/official-stockfish/WDL_model/assets/28635489/92049dd4-9f6b-476a-8dff-92f837043649)

![patch](https://github.com/official-stockfish/WDL_model/assets/28635489/8647a3dd-25d0-40b0-9f77-e1f34c643110)
