### PR TITLE
allow filtering based on estimated nElo difference

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -734,6 +734,11 @@ int main(int argc, char const *argv[]) {
         }
 
         std::cout << "Filtering pgn files with nElo in [" << mi << ", " << ma << "]" << std::endl;
+        if (mi != -ma && !cmd.has_argument("--SPRTonly", true)) {
+            std::cout << "Warning: Asymmetric nElo window suggests --SPRTonly should be used!"
+                      << std::endl;
+        }
+
         filter_files(files_pgn, meta_map, EloFilterStrategy(mi, ma));
     }
 

--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -475,11 +475,11 @@ class EloFilterStrategy {
 
     double pentanomialToEloDiff(const std::vector<int> &pentanomial) const {
         auto pairs            = std::accumulate(pentanomial.begin(), pentanomial.end(), 0);
-        const double WW       = double(pentanomial[0]) / pairs;
-        const double WD       = double(pentanomial[1]) / pairs;
+        const double WW       = double(pentanomial[4]) / pairs;
+        const double WD       = double(pentanomial[3]) / pairs;
         const double WLDD     = double(pentanomial[2]) / pairs;
-        const double LD       = double(pentanomial[3]) / pairs;
-        const double LL       = double(pentanomial[4]) / pairs;
+        const double LD       = double(pentanomial[1]) / pairs;
+        const double LL       = double(pentanomial[0]) / pairs;
         const double score    = WW + 0.75 * WD + 0.5 * WLDD + 0.25 * LD;
         const double WW_dev   = WW * std::pow((1 - score), 2);
         const double WD_dev   = WD * std::pow((0.75 - score), 2);

--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -466,6 +466,47 @@ class ThreadsFilterStrategy {
     }
 };
 
+class EloFilterStrategy {
+    double EloDiff;
+
+   public:
+    EloFilterStrategy(double ed) : EloDiff(ed) {}
+
+    double pentanomialToEloDiff(const std::vector<int> &pentanomial) const {
+        auto pairs            = std::accumulate(pentanomial.begin(), pentanomial.end(), 0);
+        const double WW       = double(pentanomial[0]) / pairs;
+        const double WD       = double(pentanomial[1]) / pairs;
+        const double WLDD     = double(pentanomial[2]) / pairs;
+        const double LD       = double(pentanomial[3]) / pairs;
+        const double LL       = double(pentanomial[4]) / pairs;
+        const double score    = WW + 0.75 * WD + 0.5 * WLDD + 0.25 * LD;
+        const double WW_dev   = WW * std::pow((1 - score), 2);
+        const double WD_dev   = WD * std::pow((0.75 - score), 2);
+        const double WLDD_dev = WLDD * std::pow((0.5 - score), 2);
+        const double LD_dev   = LD * std::pow((0.25 - score), 2);
+        const double LL_dev   = LL * std::pow((0 - score), 2);
+        const double variance = WW_dev + WD_dev + WLDD_dev + LD_dev + LL_dev;
+        return (score - 0.5) / std::sqrt(2 * variance) * (800 / std::log(10));
+    }
+
+    bool apply(const std::string &filename, const map_meta &meta_map) const {
+        if (meta_map.find(filename) == meta_map.end()) {
+            return true;
+        }
+
+        if (!meta_map.at(filename).pentanomial.has_value()) {
+            return true;
+        }
+
+        double fileEloDiff = pentanomialToEloDiff(meta_map.at(filename).pentanomial.value());
+        if (std::abs(fileEloDiff) <= EloDiff) {
+            return false;
+        }
+
+        return true;
+    }
+};
+
 class SprtFilterStrategy {
    public:
     bool apply(const std::string &filename, const map_meta &meta_map) const {
@@ -559,6 +600,7 @@ void print_usage(char const *program_name) {
     ss << "  --matchThreads <N>    Filter data based on used threads in metadata" << "\n";
     ss << "  --matchBook <regex>   Filter data based on book name in metadata" << "\n";
     ss << "  --matchBookInvert     Invert the filter" << "\n";
+    ss << "  --matchMaxEloDiff <X> Filter data based on estimated nElo difference" << "\n";
     ss << "  --SPRTonly            Analyse only pgns from SPRT tests" << "\n";
     ss << "  --fixFENsource        Patch move counters lost by cutechess-cli based on FENs in this file" << "\n";
     ss << "  --binWidth            bin position scores for faster processing and smoother densities (default 5)" << "\n";
@@ -676,6 +718,13 @@ int main(int argc, char const *argv[]) {
 
         std::cout << "Filtering pgn files using threads = " << threads << std::endl;
         filter_files(files_pgn, meta_map, ThreadsFilterStrategy(threads));
+    }
+
+    if (cmd.has_argument("--matchMaxEloDiff")) {
+        double EloDiff = std::stod(cmd.get_argument("--matchMaxEloDiff"));
+
+        std::cout << "Filtering pgn files using EloDiff = " << EloDiff << std::endl;
+        filter_files(files_pgn, meta_map, EloFilterStrategy(EloDiff));
     }
 
     if (cmd.has_argument("--fixFENsource")) {

--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <numeric>
 #include <regex>
 #include <set>
 #include <sstream>

--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -467,10 +467,10 @@ class ThreadsFilterStrategy {
 };
 
 class EloFilterStrategy {
-    double EloDiff;
+    double MaxEloDiff;
 
    public:
-    EloFilterStrategy(double ed) : EloDiff(ed) {}
+    EloFilterStrategy(double m) : MaxEloDiff(m) {}
 
     double pentanomialToEloDiff(const std::vector<int> &pentanomial) const {
         auto pairs            = std::accumulate(pentanomial.begin(), pentanomial.end(), 0);
@@ -499,7 +499,7 @@ class EloFilterStrategy {
         }
 
         double fileEloDiff = pentanomialToEloDiff(meta_map.at(filename).pentanomial.value());
-        if (std::abs(fileEloDiff) <= EloDiff) {
+        if (std::abs(fileEloDiff) <= MaxEloDiff) {
             return false;
         }
 
@@ -721,10 +721,10 @@ int main(int argc, char const *argv[]) {
     }
 
     if (cmd.has_argument("--matchMaxEloDiff")) {
-        double EloDiff = std::stod(cmd.get_argument("--matchMaxEloDiff"));
+        double MaxEloDiff = std::stod(cmd.get_argument("--matchMaxEloDiff"));
 
-        std::cout << "Filtering pgn files using EloDiff = " << EloDiff << std::endl;
-        filter_files(files_pgn, meta_map, EloFilterStrategy(EloDiff));
+        std::cout << "Filtering pgn files using MaxEloDiff = " << MaxEloDiff << std::endl;
+        filter_files(files_pgn, meta_map, EloFilterStrategy(MaxEloDiff));
     }
 
     if (cmd.has_argument("--fixFENsource")) {

--- a/scoreWDLstat.hpp
+++ b/scoreWDLstat.hpp
@@ -53,6 +53,7 @@ struct TestMetaData {
     std::optional<std::string> book, new_tc, resolved_base, resolved_new, tc;
     std::optional<int> threads;
     std::optional<bool> sprt;
+    std::optional<std::vector<int>> pentanomial;
 };
 
 template <typename T = std::string>
@@ -76,6 +77,9 @@ void from_json(const nlohmann::json &nlohmann_json_j, TestMetaData &nlohmann_jso
     nlohmann_json_t.resolved_new  = get_optional(j, "resolved_new");
     nlohmann_json_t.tc            = get_optional(j, "tc");
     nlohmann_json_t.threads       = get_optional<int>(j, "threads");
+
+    auto &jr                    = nlohmann_json_j["results"];
+    nlohmann_json_t.pentanomial = get_optional<std::vector<int>>(jr, "pentanomial");
 }
 
 /// @brief Custom stof implementation to avoid locale issues, once clang supports std::from_chars

--- a/updateWDL.sh
+++ b/updateWDL.sh
@@ -8,11 +8,11 @@ set -e
 default_firstrev=6fc7da44ad9c7e2ba6062d5c79daafd29a4dcd6f
 default_lastrev=HEAD
 default_materialMin=17
-default_matchMaxEloDiff=5
+default_EloDiffMax=5
 firstrev=$default_firstrev
 lastrev=$default_lastrev
 materialMin=$default_materialMin
-matchMaxEloDiff=$default_matchMaxEloDiff
+EloDiffMax=$default_EloDiffMax
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -28,17 +28,17 @@ while [[ $# -gt 0 ]]; do
         materialMin="$2"
         shift 2
         ;;
-    --matchMaxEloDiff)
-        matchMaxEloDiff="$2"
+    --EloDiffMax)
+        EloDiffMax="$2"
         shift 2
         ;;
     --help)
         echo "Usage: $0 [OPTIONS]"
         echo "Options:"
-        echo "  --firstrev FIRSTREV                First SF commit to collect games from (default: $default_firstrev)"
-        echo "  --lastrev LASTREV                  Last SF commit to collect games from (default: $default_lastrev)"
-        echo "  --materialMin MATERIALMIN          Parameter passed to scoreWDL.py (default: $default_materialMin)"
-        echo "  --matchMaxEloDiff MATCHMAXELODIFF  Parameter passed to scoreWDLstat (default: $default_matchMaxEloDiff)"
+        echo "  --firstrev FIRSTREV        First SF commit to collect games from (default: $default_firstrev)"
+        echo "  --lastrev LASTREV          Last SF commit to collect games from (default: $default_lastrev)"
+        echo "  --materialMin MATERIALMIN  Parameter passed to scoreWDL.py (default: $default_materialMin)"
+        echo "  --EloDiffMax ELODIFFMAX    Parameter passed to scoreWDLstat (default: $default_EloDiffMax)"
         exit 0
         ;;
     *)
@@ -47,7 +47,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-echo "Running: $0 --firstrev $firstrev --lasttrev $lastrev --materialMin $materialMin --matchMaxEloDiff $matchMaxEloDiff"
+echo "Running: $0 --firstrev $firstrev --lasttrev $lastrev --materialMin $materialMin --EloDiffMax $EloDiffMax"
 
 echo "started at: " $(date)
 
@@ -167,12 +167,12 @@ cd ..
 make >&make.log
 
 echo "Look recursively in directory $pgnpath for games with max nElo" \
-    "difference $matchMaxEloDiff using" \
+    "difference $EloDiffMax using" \
     "books matching \"$bookname\" for SF revisions between $firstrev (from" \
     "$oldepoch) and $lastrev (from $newepoch)."
 
 # obtain the WDL data from games of the SF revisions of interest
-./scoreWDLstat --dir $pgnpath -r --matchTC "60\+0.6" --matchThreads 1 --matchMaxEloDiff $matchMaxEloDiff --matchRev $regex_pattern --matchBook "$bookname" --fixFENsource "$fixfen.gz" -o updateWDL.json >&scoreWDLstat.log
+./scoreWDLstat --dir $pgnpath -r --matchTC "60\+0.6" --matchThreads 1 --EloDiffMax $EloDiffMax --matchRev $regex_pattern --matchBook "$bookname" --fixFENsource "$fixfen.gz" -o updateWDL.json >&scoreWDLstat.log
 
 gamescount=$(grep -o '[0-9]\+ games' scoreWDLstat.log | grep -o '[0-9]\+')
 

--- a/updateWDL.sh
+++ b/updateWDL.sh
@@ -8,9 +8,11 @@ set -e
 default_firstrev=6fc7da44ad9c7e2ba6062d5c79daafd29a4dcd6f
 default_lastrev=HEAD
 default_materialMin=17
+default_matchMaxEloDiff=5
 firstrev=$default_firstrev
 lastrev=$default_lastrev
 materialMin=$default_materialMin
+matchMaxEloDiff=$default_matchMaxEloDiff
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -26,12 +28,17 @@ while [[ $# -gt 0 ]]; do
         materialMin="$2"
         shift 2
         ;;
+    --matchMaxEloDiff)
+        matchMaxEloDiff="$2"
+        shift 2
+        ;;
     --help)
         echo "Usage: $0 [OPTIONS]"
         echo "Options:"
-        echo "  --firstrev    FIRSTREV      First SF commit to collect games from (default: $default_firstrev)"
-        echo "  --lastrev     LASTREV       Last SF commit to collect games from (default: $default_lastrev)"
-        echo "  --materialMin MATERIALMIN   Parameter passed to scoreWDL.py (default: $default_materialMin)"
+        echo "  --firstrev FIRSTREV                First SF commit to collect games from (default: $default_firstrev)"
+        echo "  --lastrev LASTREV                  Last SF commit to collect games from (default: $default_lastrev)"
+        echo "  --materialMin MATERIALMIN          Parameter passed to scoreWDL.py (default: $default_materialMin)"
+        echo "  --matchMaxEloDiff MATCHMAXELODIFF  Parameter passed to scoreWDL.py (default: $default_matchMaxEloDiff)"
         exit 0
         ;;
     *)
@@ -40,7 +47,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-echo "Running: $0 --firstrev $firstrev --lasttrev $lastrev --materialMin $materialMin"
+echo "Running: $0 --firstrev $firstrev --lasttrev $lastrev --materialMin $materialMin --matchMaxEloDiff $matchMaxEloDiff"
 
 echo "started at: " $(date)
 
@@ -164,7 +171,7 @@ echo "Look recursively in directory $pgnpath for games from SPRT tests using" \
     "$oldepoch) and $lastrev (from $newepoch)."
 
 # obtain the WDL data from games of SPRT tests of the SF revisions of interest
-./scoreWDLstat --dir $pgnpath -r --matchTC "60\+0.6" --matchThreads 1 --matchRev $regex_pattern --matchBook "$bookname" --fixFENsource "$fixfen.gz" --SPRTonly -o updateWDL.json >&scoreWDLstat.log
+./scoreWDLstat --dir $pgnpath -r --matchTC "60\+0.6" --matchThreads 1 --matchMaxEloDiff $matchMaxEloDiff --matchRev $regex_pattern --matchBook "$bookname" --fixFENsource "$fixfen.gz" --SPRTonly -o updateWDL.json >&scoreWDLstat.log
 
 gamescount=$(grep -o '[0-9]\+ games' scoreWDLstat.log | grep -o '[0-9]\+')
 

--- a/updateWDL.sh
+++ b/updateWDL.sh
@@ -38,7 +38,7 @@ while [[ $# -gt 0 ]]; do
         echo "  --firstrev FIRSTREV                First SF commit to collect games from (default: $default_firstrev)"
         echo "  --lastrev LASTREV                  Last SF commit to collect games from (default: $default_lastrev)"
         echo "  --materialMin MATERIALMIN          Parameter passed to scoreWDL.py (default: $default_materialMin)"
-        echo "  --matchMaxEloDiff MATCHMAXELODIFF  Parameter passed to scoreWDL.py (default: $default_matchMaxEloDiff)"
+        echo "  --matchMaxEloDiff MATCHMAXELODIFF  Parameter passed to scoreWDLstat (default: $default_matchMaxEloDiff)"
         exit 0
         ;;
     *)

--- a/updateWDL.sh
+++ b/updateWDL.sh
@@ -166,12 +166,13 @@ cd ..
 # compile scoreWDLstat if needed
 make >&make.log
 
-echo "Look recursively in directory $pgnpath for games from SPRT tests using" \
+echo "Look recursively in directory $pgnpath for games with max nElo" \
+    "difference $matchMaxEloDiff using" \
     "books matching \"$bookname\" for SF revisions between $firstrev (from" \
     "$oldepoch) and $lastrev (from $newepoch)."
 
-# obtain the WDL data from games of SPRT tests of the SF revisions of interest
-./scoreWDLstat --dir $pgnpath -r --matchTC "60\+0.6" --matchThreads 1 --matchMaxEloDiff $matchMaxEloDiff --matchRev $regex_pattern --matchBook "$bookname" --fixFENsource "$fixfen.gz" --SPRTonly -o updateWDL.json >&scoreWDLstat.log
+# obtain the WDL data from games of the SF revisions of interest
+./scoreWDLstat --dir $pgnpath -r --matchTC "60\+0.6" --matchThreads 1 --matchMaxEloDiff $matchMaxEloDiff --matchRev $regex_pattern --matchBook "$bookname" --fixFENsource "$fixfen.gz" -o updateWDL.json >&scoreWDLstat.log
 
 gamescount=$(grep -o '[0-9]\+ games' scoreWDLstat.log | grep -o '[0-9]\+')
 


### PR DESCRIPTION
This PR allows filtering the pgn data based on estimated nElo difference, as discussed on discord with @vondele.

I took the computation of the nElo difference from [fast-chess](https://github.com/Disservin/fast-chess/blob/4dbbc9f58bb4fd7498d92b0a27ef385f2a52f9bc/src/elo/elo_pentanomial.cpp#L25).

For the update script I set the default maximal nElo difference to 5.

Example usage:
```
> ./scoreWDLstat -r --EloDiffMax 0 --matchRev 61acbfc7d310ed6044ba4fc5ef91a6c382d1c9a6 --matchBook UHO_Lichess_4852_v1.epd
Looking (recursively) for pgn files in ./pgns
Found 164289 .pgn(.gz) files in total.
Filtering pgn files matching the book name UHO_Lichess_4852_v1.epd
Filtering pgn files matching revision SHA 61acbfc7d310ed6044ba4fc5ef91a6c382d1c9a6
Filtering pgn files with nElo in [-0, 0]
Found 0 .pgn(.gz) files, creating 0 chunks for processing.
```
```
> ./scoreWDLstat -r --EloDiffMax 1.95 --matchRev 61acbfc7d310ed6044ba4fc5ef91a6c382d1c9a6 --matchBook UHO_Lichess_4852_v1.epd
Looking (recursively) for pgn files in ./pgns
Found 164289 .pgn(.gz) files in total.
Filtering pgn files matching the book name UHO_Lichess_4852_v1.epd
Filtering pgn files matching revision SHA 61acbfc7d310ed6044ba4fc5ef91a6c382d1c9a6
Filtering pgn files with nElo in [-1.95, 1.95]
Found 9 .pgn(.gz) files, creating 9 chunks for processing.
```
```
> ./scoreWDLstat -r --EloDiffMax 100 --matchRev 61acbfc7d310ed6044ba4fc5ef91a6c382d1c9a6 --matchBook UHO_Lichess_4852_v1.epd
Looking (recursively) for pgn files in ./pgns
Found 164289 .pgn(.gz) files in total.
Filtering pgn files matching the book name UHO_Lichess_4852_v1.epd
Filtering pgn files matching revision SHA 61acbfc7d310ed6044ba4fc5ef91a6c382d1c9a6
Filtering pgn files with nElo in [-100, 100]
Found 15 .pgn(.gz) files, creating 15 chunks for processing.
```
```
> ./scoreWDLstat -r --EloDiffMin -10 --EloDiffMax 1.95 --SPRTonly --matchRev 61acbfc7d310ed6044ba4fc5ef91a6c382d1c9a6 --matchBook UHO_Lichess_4852_v1.epd
Looking (recursively) for pgn files in ./pgns
Found 164289 .pgn(.gz) files in total.
Filtering pgn files matching the book name UHO_Lichess_4852_v1.epd
Filtering pgn files matching revision SHA 61acbfc7d310ed6044ba4fc5ef91a6c382d1c9a6
Filtering pgn files with nElo in [-10, 1.95]
Found 15 .pgn(.gz) files, creating 15 chunks for processing.
```

Without the filtering option behaviour is like master:
```
> ./scoreWDLstat -r --matchRev 61acbfc7d310ed6044ba4fc5ef91a6c382d1c9a6 --matchBook UHO_Lichess_4852_v1.epd
Looking (recursively) for pgn files in ./pgns
Found 164289 .pgn(.gz) files in total.
Filtering pgn files matching the book name UHO_Lichess_4852_v1.epd
Filtering pgn files matching revision SHA 61acbfc7d310ed6044ba4fc5ef91a6c382d1c9a6
Found 15 .pgn(.gz) files, creating 15 chunks for processing.
```