### PR TITLE
Improve stof

### DIFF
--- a/scoreWDLstat.hpp
+++ b/scoreWDLstat.hpp
@@ -83,8 +83,6 @@ void from_json(const nlohmann::json &nlohmann_json_j, TestMetaData &nlohmann_jso
     nlohmann_json_t.pentanomial = get_optional<std::vector<int>>(jr, "pentanomial");
 }
 
-// #if (defined(__clang__) && __clang_major__ < 20) || (__GLIBCXX__ && __GLIBCXX__ < 20200122)
-
 #if (defined(__clang__) && __clang_major__ < 20) || \
     !(defined(__GNUC__) && (__GNUC__ >= 11 && __GNUC_MINOR__ >= 1))
 /// @brief Custom stof implementation to avoid locale issues, once clang supports std::from_chars


### PR DESCRIPTION
Use the more correct and fast implementation from the STL to parse floating point numbers.
Upcoming clang release finally implements it and gcc has had this for quite some time now, since gcc 11.1.

Also do some proper pointer checks for the custom implementation.

No functional change