### PR TITLE
make pgn parsing more robust

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -210,17 +210,19 @@ class Analyze : public pgn::Visitor {
                 [&](const map_t::constructor &ctor) { ctor(std::move(key), 1); });
         }
 
-        Move m;
+        try {
+            Move m = uci::parseSan(board, move, moves);
 
-        m = uci::parseSan(board, move, moves);
+            // chess-lib may call move() with empty strings for move
+            if (m == Move::NO_MOVE) {
+                this->skipPgn(true);
+                return;
+            }
 
-        // chess-lib may call move() with empty strings for move
-        if (m == Move::NO_MOVE) {
+            board.makeMove<true>(m);
+        } catch (const uci::AmbiguousMoveError &e) {
             this->skipPgn(true);
-            return;
         }
-
-        board.makeMove<true>(m);
     }
 
     void endPgn() override {

--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -210,7 +210,17 @@ class Analyze : public pgn::Visitor {
                 [&](const map_t::constructor &ctor) { ctor(std::move(key), 1); });
         }
 
-        board.makeMove<true>(uci::parseSan(board, move, moves));
+        Move m;
+
+        m = uci::parseSan(board, move, moves);
+
+        // chess-lib may call move() with empty strings for move
+        if (m == Move::NO_MOVE) {
+            this->skipPgn(true);
+            return;
+        }
+
+        board.makeMove<true>(m);
     }
 
     void endPgn() override {

--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -221,6 +221,7 @@ class Analyze : public pgn::Visitor {
 
             board.makeMove<true>(m);
         } catch (const uci::AmbiguousMoveError &e) {
+            std::cerr << e.what() << '\n';
             this->skipPgn(true);
         }
     }


### PR DESCRIPTION
Import the fix from https://github.com/vondele/fastpopular/commit/7d4504d412ca8dca625eeabb3d4d6487418cb573 to make the analysis tool be more robust with corrupt pgn files.

@Disservin You could add the try block we discussed here or in a separate PR. You know best what precisely is needed. Thanks!

Tested for non-functionality.