### PR TITLE
Update chess-library to 0.8.4

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -274,11 +274,10 @@ void ana_files(const std::vector<std::string> &files, const std::string &regex_e
 
             pgn::StreamParser parser(iss);
 
-            try {
-                parser.readGames(*vis);
-            } catch (const std::exception &e) {
-                std::cout << "Error when parsing: " << file << std::endl;
-                std::cerr << e.what() << '\n';
+            auto error = parser.readGames(*vis);
+
+            if (error) {
+                std::cerr << "Error while parsing: " << file << ". Error: " << error.message() << std::endl;
             }
         };
 


### PR DESCRIPTION
Uses error codes during parsing instead of exceptions. Through fuzzing a few minor issues were fixed, which could cause a parser crash, which shouldn't be the case anymore.