### PR TITLE
exit with an error if file not found

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -660,6 +660,10 @@ int main(int argc, char const *argv[]) {
 
     if (cmd.has_argument("--file")) {
         files_pgn = {cmd.get_argument("--file")};
+        if (!fs::exists(files_pgn[0])) {
+            std::cout << "Error: File not found: " << files_pgn[0] << std::endl;
+            std::exit(1);
+        }
     } else {
         auto path = cmd.get_argument("--dir", default_path);
 


### PR DESCRIPTION
Master:
```
> ./scoreWDLstat --file foo
Found 1 .pgn(.gz) files in total.
Found 1 .pgn(.gz) files, creating 1 chunks for processing.
Progress: 1/1
Time taken: 0.001s
Wrote 0 scored positions from 0 games to scoreWDLstat.json for analysis.
```

Patch:
```
> ./scoreWDLstat --file foo
Error: File not found: foo
```