### PR TITLE
add "Chess960" variant from fastchess

### DIFF
--- a/scoreWDLstat.cpp
+++ b/scoreWDLstat.cpp
@@ -113,7 +113,7 @@ class Analyze : public pgn::Visitor {
             }
         }
 
-        if (key == "Variant" && value == "fischerandom") {
+        if (key == "Variant" && (value == "fischerandom" || value == "Chess960")) {
             board.set960(true);
         }
 


### PR DESCRIPTION
This PR allows the correct parsing of fastchess PGNs with (D)FRC games.

For future reference: the tag `Variant` can (and does) appear after the tag `FEN` in PGN files. The parsing code in this repo still deals correctly with that case. The only downside is that the chess-lib function `setFenInternal` will be called twice. But since (D)FRC games are extremely rare, it is probably not worth it to make the parsing code more complicated.